### PR TITLE
Split PERK into doctrine + bundle stages; Dota-style bans; confirm modals; opponent army on board

### DIFF
--- a/game/core/src/scenes/RankedPlayScene.ts
+++ b/game/core/src/scenes/RankedPlayScene.ts
@@ -5,7 +5,6 @@ import {
     FightStateManager,
     Spell,
     getFactionOf,
-    GridMath,
     HoCConfig,
     TeamVals,
     ToFactionName,
@@ -842,10 +841,10 @@ export class RankedPlayScene extends Sandbox {
         return this.viewerTeam;
     }
     /**
-     * During placement the opponent's placement zone is never drawn (see getPlacementDrawTeam).
-     * Instead, lay out the units we have revealed (scouted) inside the opponent's placement area,
-     * each on its own cell so they never stack. These are synthetic display positions — the
-     * opponent's real placement cells stay hidden.
+     * During placement the opponent's placement zone is never drawn (see getPlacementDrawTeam). Instead,
+     * lay the opponent's revealed roster out in a single horizontal LINE across the top of the board (their
+     * side), evenly spaced so each unit gets its own spot and none overlap. These are synthetic display
+     * positions — the opponent's real placement cells stay hidden until the fight starts.
      */
     protected override getRevealedOpponentUnitPositions(units: SandboxSceneUnitState[]): Map<string, HoCMath.XY> {
         const positions = new Map<string, HoCMath.XY>();
@@ -861,35 +860,18 @@ export class RankedPlayScene extends Sandbox {
             return positions;
         }
 
+        // Spread the roster in one horizontal line across the board width, on the opponent's edge (top of the
+        // board for a LOWER viewer, bottom for an UPPER viewer). (index + 0.5)/total centers each unit in its
+        // own equal-width slot with a half-slot margin from both edges, so end units don't overflow.
         const gs = this.sc_sceneSettings.getGridSettings();
-        const slots: HoCMath.XY[] = [];
-        const seen = new Set<number>();
-        for (const placementIndex of [0, 1]) {
-            const placement = this.getPlacement(opponentTeam, placementIndex);
-            if (!placement) {
-                continue;
-            }
-            for (const cell of placement.possibleCellPositions(true)) {
-                if (!cell) {
-                    continue;
-                }
-                const hash = (cell.x << 4) | cell.y;
-                if (seen.has(hash)) {
-                    continue;
-                }
-                seen.add(hash);
-                slots.push(GridMath.getPositionForCell(cell, gs.getMinX(), gs.getStep(), gs.getHalfStep()));
-            }
-        }
-        if (!slots.length) {
-            return positions;
-        }
-        // Stable order so each revealed unit keeps the same cell across snapshots.
-        slots.sort((a, b) => a.y - b.y || a.x - b.x);
-
+        const minX = gs.getMinX();
+        const maxX = gs.getMaxX();
+        const isLowerViewer = this.viewerTeam === TeamVals.LOWER;
+        const lineY = isLowerViewer ? gs.getMaxY() : gs.getMinY();
+        const total = revealedUnits.length;
         revealedUnits.forEach((unit, index) => {
-            // More revealed units than cells is not expected; modulo just keeps it bounded.
-            positions.set(unit.properties.id, slots[index % slots.length]);
+            const fraction = (index + 0.5) / total;
+            positions.set(unit.properties.id, { x: minX + (maxX - minX) * fraction, y: lineY });
         });
         return positions;
     }

--- a/game/core/src/scenes/Sandbox.ts
+++ b/game/core/src/scenes/Sandbox.ts
@@ -1666,11 +1666,36 @@ export class Sandbox extends PixiScene {
         this.rangedProjectiles.clear();
 
         const existingUnits = Array.from(this.unitsHolder.getAllUnits().values()) as RenderableUnit[];
-        if (existingUnits.length) {
-            this.destroySpecificUnits(existingUnits, true, false);
+        // During placement, KEEP already-drawn revealed opponent units alive across snapshot rebuilds instead
+        // of destroying + recreating them each tick (which makes them flicker / play their spawn animation
+        // repeatedly while the player drags their own units). They are non-interactive ghosts with no grid
+        // occupancy, so preserving them is safe; their positions are re-applied below if they changed.
+        const preservedRevealedOpponentUnitIds = new Set<string>();
+        const preservedRevealedOpponentUnits = new Map<string, RenderableUnit>();
+        if (!snapshot.fightStarted) {
+            for (const id of this.revealedOpponentUnitIds) {
+                preservedRevealedOpponentUnitIds.add(id);
+                const u = this.unitsHolder.getAllUnits().get(id) as RenderableUnit | undefined;
+                if (u) {
+                    preservedRevealedOpponentUnits.set(id, u);
+                }
+            }
+        }
+        const unitsToDestroy = !snapshot.fightStarted
+            ? existingUnits.filter((u) => !preservedRevealedOpponentUnitIds.has(u.getId()))
+            : existingUnits;
+        if (unitsToDestroy.length) {
+            this.destroySpecificUnits(unitsToDestroy, true, false);
         }
         this.clearPlacementBench();
-        this.revealedOpponentUnitIds.clear();
+        if (!snapshot.fightStarted) {
+            // Keep the preserved set; non-preserved (everything else) is already cleared above.
+            for (const id of preservedRevealedOpponentUnitIds) {
+                this.revealedOpponentUnitIds.add(id);
+            }
+        } else {
+            this.revealedOpponentUnitIds.clear();
+        }
 
         const gs = this.sc_sceneSettings.getGridSettings();
         const unitsContainer = this.drawer.getUnitsContainer();
@@ -1709,18 +1734,25 @@ export class Sandbox extends PixiScene {
         }
 
         for (const unitState of snapshot.units) {
-            const unit = this.createRenderableUnitFromSceneState(unitState);
+            const revealedPosition = revealedOpponentPositions.get(unitState.properties.id);
+            const isRevealedOpponent = !snapshot.fightStarted && !!revealedPosition;
+            // Reuse a preserved revealed-opponent unit instead of recreating it (avoids the spawn/flicker on
+            // every placement rebuild). Falls through to create+render for fresh ones (or after fight start).
+            let unit: RenderableUnit | undefined;
+            if (isRevealedOpponent) {
+                unit = preservedRevealedOpponentUnits.get(unitState.properties.id);
+            }
+            if (!unit) {
+                unit = this.createRenderableUnitFromSceneState(unitState);
+            }
             this.unitsHolder.addUnit(unit);
             if (!unitState.placed || !unitState.cells.length) {
                 const benchPosition = benchPositions.get(unitState.properties.id);
                 if (benchPosition) {
                     this.renderUnplacedBenchUnit(unit, benchPosition, unitState);
-                } else {
-                    const revealedPosition = revealedOpponentPositions.get(unitState.properties.id);
-                    if (revealedPosition) {
-                        this.revealedOpponentUnitIds.add(unit.getId());
-                        this.renderRevealedOpponentUnit(unit, revealedPosition);
-                    }
+                } else if (revealedPosition) {
+                    this.revealedOpponentUnitIds.add(unit.getId());
+                    this.renderRevealedOpponentUnit(unit, revealedPosition);
                 }
                 continue;
             }

--- a/game/core/src/ui/PickAndBan/index.tsx
+++ b/game/core/src/ui/PickAndBan/index.tsx
@@ -2,13 +2,27 @@ import {
     Artifact,
     CREATURES_JSON,
     CreatureVals,
+    getCreatureLevel,
     getCreaturesByLevel,
     HoCConfig,
     Perk,
     PickPhaseVals,
     type TeamType,
 } from "@heroesofcrypto/common";
-import { Box, Button, Card, CardContent, Chip, CircularProgress, Divider, Sheet, Tooltip, Typography } from "@mui/joy";
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Chip,
+    CircularProgress,
+    Divider,
+    Modal,
+    ModalDialog,
+    Sheet,
+    Tooltip,
+    Typography,
+} from "@mui/joy";
 import React, { useEffect, useState } from "react";
 
 import { images as rawImages } from "../../generated/image_imports";
@@ -176,6 +190,165 @@ const CreatureDetailPanel: React.FC<{ creatureId: number }> = ({ creatureId }) =
     );
 };
 
+// Confirmation modal shown when a player clicks a creature to pick: a centered portrait + stats + abilities
+// (the same detail the hover panel shows on the left) with Confirm / Cancel buttons. The pick only fires on
+// Confirm, so the player can review the unit before committing (instead of the previous instant-pick-on-click).
+const PickConfirmModal: React.FC<{
+    open: boolean;
+    creatureId: number;
+    busy: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+}> = ({ open, creatureId, busy, onConfirm, onCancel }) => {
+    const entry = creatureFullConfig(creatureId);
+    const img = creatureImage(creatureId);
+    return (
+        <Modal open={open} onClose={onCancel}>
+            <ModalDialog
+                sx={{
+                    bgcolor: "rgba(8,10,18,0.97)",
+                    border: "1px solid rgba(255,255,255,0.16)",
+                    color: "#e7e9f0",
+                    borderRadius: "14px",
+                    maxWidth: 360,
+                    width: "90vw",
+                }}
+            >
+                {entry ? (
+                    <>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
+                            {img && (
+                                <Box
+                                    component="img"
+                                    src={img}
+                                    alt={entry.config.name}
+                                    sx={{ width: 64, height: 64, borderRadius: "10px", objectFit: "cover" }}
+                                />
+                            )}
+                            <Box>
+                                <Typography level="title-md">{entry.config.name}</Typography>
+                                <Typography level="body-xs" sx={{ opacity: 0.65 }}>
+                                    {entry.faction} · Lvl {entry.config.level} ·{" "}
+                                    {entry.config.size === 2 ? "2×2" : "1×1"}
+                                </Typography>
+                            </Box>
+                        </Box>
+                        <Box
+                            sx={{
+                                display: "grid",
+                                gridTemplateColumns: "1fr 1fr",
+                                columnGap: 1.5,
+                                rowGap: 0.25,
+                                mb: 1,
+                            }}
+                        >
+                            <StatCell label="HP" value={entry.config.hp} />
+                            <StatCell label="Armor" value={entry.config.armor} />
+                            <StatCell label="Attack" value={entry.config.attack} />
+                            <StatCell
+                                label="Damage"
+                                value={`${entry.config.attack_damage_min}–${entry.config.attack_damage_max}`}
+                            />
+                            <StatCell label="Speed" value={entry.config.speed} />
+                            <StatCell label="Move" value={Math.round(entry.config.steps)} />
+                            <StatCell label="Type" value={entry.config.attack_type === "RANGE" ? "Ranged" : "Melee"} />
+                            <StatCell label="Resist" value={`${entry.config.magic_resist}%`} />
+                        </Box>
+                        <Divider sx={{ my: 0.5 }} />
+                        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 1 }}>
+                            <Button variant="soft" color="neutral" onClick={onCancel} disabled={busy}>
+                                Cancel
+                            </Button>
+                            <Button variant="solid" color="success" onClick={onConfirm} loading={busy}>
+                                Confirm pick
+                            </Button>
+                        </Box>
+                    </>
+                ) : (
+                    <>
+                        <Typography level="title-md">{creatureName(creatureId)}</Typography>
+                        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}>
+                            <Button variant="soft" color="neutral" onClick={onCancel} disabled={busy}>
+                                Cancel
+                            </Button>
+                            <Button variant="solid" color="success" onClick={onConfirm} loading={busy}>
+                                Confirm pick
+                            </Button>
+                        </Box>
+                    </>
+                )}
+            </ModalDialog>
+        </Modal>
+    );
+};
+
+// Confirmation modal for a Tier-2 artifact pick: shows the artifact icon + name + description with Confirm /
+// Cancel buttons. Mirrors PickConfirmModal — the pick only fires on Confirm, so the player reviews the effect
+// before committing.
+const ArtifactConfirmModal: React.FC<{
+    open: boolean;
+    artifactId: number;
+    busy: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+}> = ({ open, artifactId, busy, onConfirm, onCancel }) => {
+    const a = artifactId ? Artifact.getTier2ArtifactProperties(artifactId as Artifact.Tier2Artifact) : undefined;
+    const img = a ? images[a.imageKey] : undefined;
+    return (
+        <Modal open={open} onClose={onCancel}>
+            <ModalDialog
+                sx={{
+                    bgcolor: "rgba(8,10,18,0.97)",
+                    border: "1px solid rgba(255,255,255,0.16)",
+                    color: "#e7e9f0",
+                    borderRadius: "14px",
+                    maxWidth: 360,
+                    width: "90vw",
+                }}
+            >
+                {a ? (
+                    <>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
+                            {img && (
+                                <Box
+                                    component="img"
+                                    src={img}
+                                    alt={a.name}
+                                    sx={{ width: 56, height: 56, objectFit: "contain" }}
+                                />
+                            )}
+                            <Typography level="title-md">{a.name}</Typography>
+                        </Box>
+                        <Typography
+                            level="body-xs"
+                            sx={{ opacity: 0.6, textTransform: "uppercase", letterSpacing: 0.5, mb: 0.5 }}
+                        >
+                            Tier-2 artifact
+                        </Typography>
+                        <Typography level="body-sm" sx={{ opacity: 0.9 }}>
+                            {Artifact.formatArtifactDescription(a)}
+                        </Typography>
+                        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}>
+                            <Button variant="soft" color="neutral" onClick={onCancel} disabled={busy}>
+                                Cancel
+                            </Button>
+                            <Button variant="solid" color="success" onClick={onConfirm} loading={busy}>
+                                Confirm pick
+                            </Button>
+                        </Box>
+                    </>
+                ) : (
+                    <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}>
+                        <Button variant="soft" color="neutral" onClick={onCancel} disabled={busy}>
+                            Cancel
+                        </Button>
+                    </Box>
+                )}
+            </ModalDialog>
+        </Modal>
+    );
+};
+
 // Emoji cue per perk (Scout / Spymaster / Blind Fury) so the vision trade-off reads at a glance.
 const PERK_ICON: Record<number, string> = {
     [Perk.Perk.THREE_REVEALS]: "🔍",
@@ -185,7 +358,7 @@ const PERK_ICON: Record<number, string> = {
 
 const PHASE_HINT: Record<number, string> = {
     [PickPhaseVals.PERK]:
-        "Choose your doctrine AND a starting bundle. Doctrine lasts the whole draft; each bundle gives two creatures and a Tier-1 artifact.",
+        "Choose your scouting doctrine. It lasts the whole draft and decides which of the opponent's army slots you can watch.",
     [PickPhaseVals.INITIAL_PICK]: "Each bundle gives you two creatures and a Tier-1 artifact. Pick one.",
     [PickPhaseVals.PICK]:
         "Greyed portraits are banned. Opponent picks are hidden — if you pick one they already took, you'll re-pick.",
@@ -201,7 +374,7 @@ const RULES_URL = "https://heroesofcrypto.io/rules";
 const phaseAction = (phase: number, level: number): string => {
     switch (phase) {
         case PickPhaseVals.PERK:
-            return "Pick one doctrine and one starting bundle to continue.";
+            return "Pick one doctrine to continue.";
         case PickPhaseVals.INITIAL_PICK:
             return "Pick one starting bundle.";
         case PickPhaseVals.PICK:
@@ -215,20 +388,23 @@ const phaseAction = (phase: number, level: number): string => {
 
 // ---- Draft progress stepper ----------------------------------------------
 
-// Doctrine + Bundle are chosen together in one combined first step.
-const STEP_LABELS = ["Doctrine + Bundle", "Lvl 1", "Lvl 2", "Lvl 3", "Artifact", "Lvl 4", "Place"];
+// Doctrine and the starting bundle are now separate first steps.
+const STEP_LABELS = ["Doctrine", "Bundle", "Lvl 1", "Lvl 2", "Lvl 3", "Artifact", "Lvl 4", "Place"];
 
 const currentStep = (phase: number, level: number): number => {
     switch (phase) {
-        case PickPhaseVals.PERK: // combined doctrine + bundle
+        case PickPhaseVals.PERK: // doctrine
             return 0;
+        case PickPhaseVals.INITIAL_PICK: // starting bundle
+            return 1;
         case PickPhaseVals.ARTIFACT_2:
-            return 4;
+            return 5;
         case PickPhaseVals.AUGMENTS:
         case PickPhaseVals.AUGMENTS_SCOUT:
-            return 6;
+            return 7;
         case PickPhaseVals.PICK:
-            return level === 4 ? 5 : level; // L1->1, L2->2, L3->3, L4->5
+            // L1->2, L2->3, L3->4, L4->6 (artifact sits at 5 between L3 and L4).
+            return level === 4 ? 6 : level + 1;
         default:
             return -1;
     }
@@ -297,7 +473,9 @@ const CreaturePortrait: React.FC<{
                     border: `2px solid ${ring}`,
                     cursor: selectable ? "pointer" : "default",
                     opacity: state === "available" ? 1 : 0.5,
-                    filter: state === "banned" || state === "taken" ? "grayscale(1)" : "none",
+                    // NOTE: the grayscale filter is applied to the <img> below, NOT to this wrapper. Putting it
+                    // on the wrapper would also desaturate the red ban slash (CSS filters affect all descendants),
+                    // turning the crimson Dota strike grey/black. Keep the wrapper filter-free so the slash stays red.
                     transition: "transform 120ms ease, box-shadow 120ms ease",
                     "&:hover": selectable
                         ? { transform: "translateY(-3px)", boxShadow: "0 0 14px rgba(120,220,150,0.6)" }
@@ -308,7 +486,12 @@ const CreaturePortrait: React.FC<{
                     <img
                         src={src}
                         alt={creatureName(creatureId)}
-                        style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                        style={{
+                            width: "100%",
+                            height: "100%",
+                            objectFit: "cover",
+                            filter: state === "banned" || state === "taken" ? "grayscale(1)" : "none",
+                        }}
                     />
                 ) : (
                     <Typography level="body-xs" sx={{ p: 1 }}>
@@ -316,20 +499,34 @@ const CreaturePortrait: React.FC<{
                     </Typography>
                 )}
                 {(state === "banned" || state === "taken") && (
+                    // Dota-style ban: a thick crimson diagonal band corner-to-corner across a greyscale
+                    // portrait (the grayscale filter is applied on the portrait wrapper above). The band has
+                    // a vertical light-to-dark gradient (highlight on top, deep crimson below), a thin
+                    // near-black core stroke down the middle, and a wide red glow — mirroring the heavy red
+                    // "X" strikethrough Dota paints over banned heroes.
                     <Box
+                        aria-hidden
                         sx={{
                             position: "absolute",
-                            inset: 0,
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            color: "#ff6b6b",
-                            fontSize: size * 0.45,
-                            fontWeight: 700,
+                            top: "50%",
+                            left: "50%",
+                            width: size * 1.55,
+                            height: Math.max(9, Math.round(size * 0.12)),
+                            transform: "translate(-50%, -50%) rotate(45deg)",
+                            background: "linear-gradient(180deg, #ff5a5a 0%, #e8202a 45%, #b8131c 100%)",
+                            borderTop: "1px solid rgba(255,180,180,0.85)",
+                            borderBottom: "2px solid rgba(0,0,0,0.55)",
+                            boxShadow: "0 0 10px rgba(232,32,42,0.9), inset 0 0 4px rgba(0,0,0,0.45)",
+                            pointerEvents: "none",
+                            "&::after": {
+                                // Thin dark center seam for the layered "embossed" look.
+                                content: '""',
+                                position: "absolute",
+                                inset: 0,
+                                borderTop: "1px solid rgba(0,0,0,0.35)",
+                            },
                         }}
-                    >
-                        ✕
-                    </Box>
+                    />
                 )}
                 {state === "picked" && (
                     <Box
@@ -484,7 +681,7 @@ const Legend: React.FC = () => (
             ✓ Yours
         </Chip>
         <Chip size="sm" variant="soft" color="danger">
-            ✕ Taken / banned
+            ⟋ Taken / banned
         </Chip>
     </Box>
 );
@@ -609,6 +806,26 @@ const BarDivider: React.FC = () => (
     <Box sx={{ width: "1px", alignSelf: "stretch", bgcolor: "rgba(255,255,255,0.14)", mx: 0.25 }} />
 );
 
+// Fixed slot layout shown for BOTH armies: [L1, L1, L2, L2, L3, L4]. Mirrors CreaturePoolByLevel = [2,2,1,1]
+// and the level-sorted creaturesPicked order the server now maintains, so a slot index maps 1:1 to a level.
+const ARMY_LAYOUT: number[] = [1, 1, 2, 2, 3, 4];
+
+// Place picked creature ids into the fixed level layout. Returns an array of length ARMY_LAYOUT.length where each cell
+// is either the picked creature id of that level (filled left-to-right within each level) or 0 when empty.
+// Empty picks get a level so the caller can render a labelled placeholder.
+const placeIntoLevelSlots = (picked: number[]): { id: number; level: number }[] => {
+    const valid = picked.filter((id) => id && id !== CreatureVals.NO_CREATURE);
+    // Bucket creatures by level, preserving arrival order within a level.
+    const byLevel: Record<number, number[]> = { 1: [], 2: [], 3: [], 4: [] };
+    for (const id of valid) {
+        const lvl = (getCreatureLevel(id) as number) || 0;
+        if (lvl >= 1 && lvl <= 4) {
+            byLevel[lvl].push(id);
+        }
+    }
+    return ARMY_LAYOUT.map((level) => ({ id: byLevel[level].shift() ?? 0, level }));
+};
+
 // Sticky bottom-center summary of the player's own draft so far — chosen doctrine (perk), picked units, and
 // picked artifacts. Stays pinned as the draft advances so the player always sees the army they're building.
 const MyDraftBar: React.FC<{
@@ -618,13 +835,11 @@ const MyDraftBar: React.FC<{
     artifactTier2: number;
     onInspect?: (creatureId: number) => void;
 }> = ({ perk, picked, artifactTier1, artifactTier2, onInspect }) => {
-    const units = picked.filter((id) => id && id !== CreatureVals.NO_CREATURE);
     const t1 = artifactTier1 ? Artifact.getTier1ArtifactProperties(artifactTier1 as Artifact.Tier1Artifact) : undefined;
     const t2 = artifactTier2 ? Artifact.getTier2ArtifactProperties(artifactTier2 as Artifact.Tier2Artifact) : undefined;
     const artifacts = [t1, t2].filter((a): a is Artifact.ArtifactProperties => !!a);
-    if (!perk && !units.length && !artifacts.length) {
-        return null;
-    }
+    // Fixed 6 slots in level order [L1,L1,L2,L2,L3,L4], filled progressively (mirrors OpponentDraftBar).
+    const slots = placeIntoLevelSlots(picked);
     return (
         <Box
             sx={{
@@ -673,42 +888,62 @@ const MyDraftBar: React.FC<{
                         </Tooltip>
                     </>
                 )}
-                {units.length > 0 && (
-                    <>
-                        <BarDivider />
-                        <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap" }}>
-                            {units.map((id, i) => {
-                                const src = creatureImage(id);
-                                return (
-                                    <Tooltip key={`${id}-${i}`} title={creatureName(id)} variant="soft">
-                                        <Box
-                                            onMouseEnter={() => onInspect?.(id)}
-                                            sx={{
-                                                width: 50,
-                                                height: 50,
-                                                borderRadius: "9px",
-                                                overflow: "hidden",
-                                                border: "1px solid rgba(120,220,150,0.5)",
-                                            }}
-                                        >
-                                            {src ? (
-                                                <img
-                                                    src={src}
-                                                    alt={creatureName(id)}
-                                                    style={{ width: "100%", height: "100%", objectFit: "cover" }}
-                                                />
-                                            ) : (
-                                                <Typography level="body-xs" sx={{ p: 0.5 }}>
-                                                    {creatureName(id)}
-                                                </Typography>
-                                            )}
-                                        </Box>
-                                    </Tooltip>
-                                );
-                            })}
-                        </Box>
-                    </>
-                )}
+                <BarDivider />
+                <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap" }}>
+                    {slots.map((slot, i) => {
+                        const id = slot.id;
+                        if (id) {
+                            const src = creatureImage(id);
+                            return (
+                                <Tooltip key={`${id}-${i}`} title={creatureName(id)} variant="soft">
+                                    <Box
+                                        onMouseEnter={() => onInspect?.(id)}
+                                        sx={{
+                                            width: 50,
+                                            height: 50,
+                                            borderRadius: "9px",
+                                            overflow: "hidden",
+                                            border: "1px solid rgba(120,220,150,0.5)",
+                                        }}
+                                    >
+                                        {src ? (
+                                            <img
+                                                src={src}
+                                                alt={creatureName(id)}
+                                                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                                            />
+                                        ) : (
+                                            <Typography level="body-xs" sx={{ p: 0.5 }}>
+                                                {creatureName(id)}
+                                            </Typography>
+                                        )}
+                                    </Box>
+                                </Tooltip>
+                            );
+                        }
+                        // Empty slot: show the level it will hold, so the layout reads as 6 ordered slots.
+                        return (
+                            <Tooltip key={`empty-${i}`} title={`Level ${slot.level} slot`} variant="soft">
+                                <Box
+                                    sx={{
+                                        width: 50,
+                                        height: 50,
+                                        borderRadius: "9px",
+                                        display: "grid",
+                                        placeItems: "center",
+                                        border: "1px dashed rgba(120,220,150,0.35)",
+                                        bgcolor: "rgba(120,220,150,0.05)",
+                                        color: "rgba(180,230,195,0.55)",
+                                        fontSize: 14,
+                                        fontWeight: 700,
+                                    }}
+                                >
+                                    L{slot.level}
+                                </Box>
+                            </Tooltip>
+                        );
+                    })}
+                </Box>
                 {artifacts.length > 0 && (
                     <>
                         <BarDivider />
@@ -759,30 +994,29 @@ interface StainedGlassProps {
     height?: number;
 }
 
-// Total creatures each team drafts — mirrors sum(CreaturePoolByLevel) = [2,2,1,1] on the server. Used to
-// render the opponent's remaining (unrevealed) slots face-down.
-const OPPONENT_ARMY_SLOTS = 6;
-
-// The opponent's army as disclosed by YOUR scouting doctrine (perk): revealed creatures show as portraits,
-// the rest as face-down slots. Spymaster reveals every slot as the opponent fills it, Scout 3 random slots,
-// Blind Fury none. `opponentPicked` is the server-revealed set (empty when nothing is visible). Sits just
-// above the "Your army" bar so both drafts are visible side-by-side at the bottom of the pick screen.
+// The opponent's army rendered as EXACTLY 6 fixed level-ordered slots [L1,L1,L2,L2,L3,L4]. Each slot shows one
+// of three states: a portrait (the opponent has picked there AND your doctrine reveals it), an eye (your
+// doctrine watches that slot but the opponent hasn't filled it yet), or a "?" (not revealed by your doctrine).
+// `opponentPicked` is a slot-ALIGNED array (length = ARMY_LAYOUT.length): the creature id at each watched slot
+// the opponent has filled, and 0 elsewhere — so a creature stays at its true positional slot (a bundle L2 at
+// index 2 vs a separately-picked L2 at index 3) instead of being bucket-filled left-to-right. `watchedSlots`
+// is the set of slot indices (0..5) your scouting doctrine watches — a watched-but-empty slot shows the eye.
 const OpponentDraftBar: React.FC<{
     opponentPicked: number[];
     opponentLabel: string;
     viewerPerk: number;
     onInspect?: (creatureId: number) => void;
 }> = ({ opponentPicked, opponentLabel, viewerPerk, onInspect }) => {
-    const revealed = opponentPicked.filter((id) => id && id !== CreatureVals.NO_CREATURE);
-    // How many of the opponent's slots YOUR doctrine lets you watch (Spymaster all, Scout 3, Blind Fury none).
-    // Watched-but-not-yet-picked slots show an eye (they flip to a portrait once the opponent picks there); the
-    // rest stay face-down. Derived from your own perk, so the "eye" slots appear immediately at draft start —
-    // before the opponent has picked anything — telling you up front which slots you'll get to see.
+    // Build the 6 fixed level-ordered slots directly from the slot-aligned reveal array (no bucketing), so each
+    // creature lands at its real slot index — preserving bundle-vs-picked ordering within a level.
+    const slots = ARMY_LAYOUT.map((level, i) => ({ id: opponentPicked[i] ?? 0, level }));
+    // The set of slot indices YOUR doctrine watches (Spymaster all, Scout 3, Blind Fury none). Watched-but-not-
+    // yet-picked slots show an eye; the rest stay face-down. Derived from your own perk, so the eye slots appear
+    // immediately at draft start, telling you up front which slots you'll get to see.
     const revealMode = Perk.getPerkRevealMode(viewerPerk as Perk.Perk);
-    const watchedSlots =
-        revealMode === "all" ? OPPONENT_ARMY_SLOTS : revealMode === "random3" ? Perk.PERK_RANDOM_REVEAL_SLOTS : 0;
-    const eyeCount = Math.max(0, Math.min(watchedSlots, OPPONENT_ARMY_SLOTS) - revealed.length);
-    const hiddenCount = Math.max(0, OPPONENT_ARMY_SLOTS - revealed.length - eyeCount);
+    const watchedCount =
+        revealMode === "all" ? ARMY_LAYOUT.length : revealMode === "random3" ? Perk.PERK_RANDOM_REVEAL_SLOTS : 0;
+    const watched = new Set(slots.slice(0, watchedCount).map((_, i) => i));
     return (
         <Box sx={{ width: "100%", display: "flex", justifyContent: "center", pt: 1.5, pointerEvents: "none" }}>
             <Sheet
@@ -808,78 +1042,87 @@ const OpponentDraftBar: React.FC<{
                 </Typography>
                 <BarDivider />
                 <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap" }}>
-                    {revealed.map((id, i) => {
-                        const src = creatureImage(id);
+                    {slots.map((slot, i) => {
+                        const id = slot.id;
+                        const isWatched = watched.has(i);
+                        if (id) {
+                            // Watched slot the opponent has filled -> reveal the creature portrait.
+                            const src = creatureImage(id);
+                            return (
+                                <Tooltip key={`opp-${id}-${i}`} title={creatureName(id)} variant="soft">
+                                    <Box
+                                        onMouseEnter={() => onInspect?.(id)}
+                                        sx={{
+                                            width: 44,
+                                            height: 44,
+                                            borderRadius: "9px",
+                                            overflow: "hidden",
+                                            border: "1px solid rgba(240,120,120,0.6)",
+                                        }}
+                                    >
+                                        {src ? (
+                                            <img
+                                                src={src}
+                                                alt={creatureName(id)}
+                                                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                                            />
+                                        ) : (
+                                            <Typography level="body-xs" sx={{ p: 0.5 }}>
+                                                {creatureName(id)}
+                                            </Typography>
+                                        )}
+                                    </Box>
+                                </Tooltip>
+                            );
+                        }
+                        if (isWatched) {
+                            // Watched but not yet picked by the opponent -> eye on this slot.
+                            return (
+                                <Tooltip
+                                    key={`opp-eye-${i}`}
+                                    title={`Level ${slot.level} — revealed by your doctrine (flips to the unit once your opponent picks here)`}
+                                    variant="soft"
+                                >
+                                    <Box
+                                        sx={{
+                                            width: 44,
+                                            height: 44,
+                                            borderRadius: "9px",
+                                            display: "grid",
+                                            placeItems: "center",
+                                            border: "1px solid rgba(240,180,90,0.55)",
+                                            bgcolor: "rgba(240,180,90,0.1)",
+                                            color: "rgba(245,205,130,0.95)",
+                                            fontSize: 20,
+                                        }}
+                                    >
+                                        👁
+                                    </Box>
+                                </Tooltip>
+                            );
+                        }
+                        // Not revealed by your doctrine -> face-down slot.
                         return (
-                            <Tooltip key={`opp-${id}-${i}`} title={creatureName(id)} variant="soft">
+                            <Tooltip key={`opp-hidden-${i}`} title={`Level ${slot.level} — hidden`} variant="soft">
                                 <Box
-                                    onMouseEnter={() => onInspect?.(id)}
                                     sx={{
                                         width: 44,
                                         height: 44,
                                         borderRadius: "9px",
-                                        overflow: "hidden",
-                                        border: "1px solid rgba(240,120,120,0.6)",
+                                        display: "grid",
+                                        placeItems: "center",
+                                        border: "1px dashed rgba(255,255,255,0.22)",
+                                        bgcolor: "rgba(255,255,255,0.04)",
+                                        color: "rgba(255,255,255,0.5)",
+                                        fontSize: 18,
+                                        fontWeight: 700,
                                     }}
                                 >
-                                    {src ? (
-                                        <img
-                                            src={src}
-                                            alt={creatureName(id)}
-                                            style={{ width: "100%", height: "100%", objectFit: "cover" }}
-                                        />
-                                    ) : (
-                                        <Typography level="body-xs" sx={{ p: 0.5 }}>
-                                            {creatureName(id)}
-                                        </Typography>
-                                    )}
+                                    ?
                                 </Box>
                             </Tooltip>
                         );
                     })}
-                    {Array.from({ length: eyeCount }).map((_, i) => (
-                        <Tooltip
-                            key={`opp-eye-${i}`}
-                            title="Revealed by your doctrine — flips to the unit once your opponent picks here"
-                            variant="soft"
-                        >
-                            <Box
-                                sx={{
-                                    width: 44,
-                                    height: 44,
-                                    borderRadius: "9px",
-                                    display: "grid",
-                                    placeItems: "center",
-                                    border: "1px solid rgba(240,180,90,0.55)",
-                                    bgcolor: "rgba(240,180,90,0.1)",
-                                    color: "rgba(245,205,130,0.95)",
-                                    fontSize: 20,
-                                }}
-                            >
-                                👁
-                            </Box>
-                        </Tooltip>
-                    ))}
-                    {Array.from({ length: hiddenCount }).map((_, i) => (
-                        <Tooltip key={`opp-hidden-${i}`} title="Hidden — not revealed by your doctrine" variant="soft">
-                            <Box
-                                sx={{
-                                    width: 44,
-                                    height: 44,
-                                    borderRadius: "9px",
-                                    display: "grid",
-                                    placeItems: "center",
-                                    border: "1px dashed rgba(255,255,255,0.22)",
-                                    bgcolor: "rgba(255,255,255,0.04)",
-                                    color: "rgba(255,255,255,0.5)",
-                                    fontSize: 18,
-                                    fontWeight: 700,
-                                }}
-                            >
-                                ?
-                            </Box>
-                        </Tooltip>
-                    ))}
                 </Box>
             </Sheet>
         </Box>
@@ -908,19 +1151,21 @@ const StainedGlassWindow: React.FC<StainedGlassProps> = ({ userTeam, opponentLab
     const [selection, setSelection] = useState<{ phase: number; value: number } | null>(null);
     // Creature currently hovered anywhere in the draft — its stats + abilities show in the left detail panel.
     const [inspectedId, setInspectedId] = useState<number>(0);
-    // Combined PERK phase does TWO independent actions on one screen, so it needs its own local choices
-    // (the single `selection` can't hold both). Locks are derived from authoritative server state below.
-    const [setupBundleChoice, setSetupBundleChoice] = useState<number>(-1);
     // Opponent picks are fully hidden by the server. The ONLY way we learn a unit is taken is by picking it
     // and getting a 409 collision back — we remember those locally so they grey out and we don't re-try them.
     const [collided, setCollided] = useState<number[]>([]);
     const [pickError, setPickError] = useState<string>("");
+    // Creature the player clicked to pick — opens the confirm modal. The actual pick only fires on Confirm.
+    const [pendingPick, setPendingPick] = useState<number>(0);
+    // Artifact the player clicked to pick — opens the confirm modal. The actual pick only fires on Confirm.
+    const [pendingArtifact, setPendingArtifact] = useState<number>(0);
 
-    // Clear the local selections whenever the phase advances.
+    // Clear the local selection whenever the phase advances.
     useEffect(() => {
         setSelection((prev) => (prev && prev.phase === pickPhase ? prev : null));
-        setSetupBundleChoice(-1);
         setPickError("");
+        setPendingPick(0);
+        setPendingArtifact(0);
     }, [pickPhase]);
 
     const send = async (value: number, fn: () => Promise<void>): Promise<void> => {
@@ -965,60 +1210,33 @@ const StainedGlassWindow: React.FC<StainedGlassProps> = ({ userTeam, opponentLab
     // "Taken" units are ONLY the ones we've collided on locally — the server never reveals opponent picks.
     const opponentTaken = collided;
     const isHandoff = pickPhase === PickPhaseVals.AUGMENTS || pickPhase === PickPhaseVals.AUGMENTS_SCOUT;
-    const isCombinedSetup = pickPhase === PickPhaseVals.PERK;
-    // Authoritative per-dimension locks for the combined phase: the server echoes the player's own perk
-    // (perk > 0) and their bundle (picked.length > 0), so both survive reload and disable their panel.
-    const perkLocked = isCombinedSetup && perk > 0;
-    const bundleLocked = isCombinedSetup && picked.length > 0;
+    // PERK is now a doctrine-only phase; the server echoes the player's perk (perk > 0), which survives reload
+    // and locks the panel.
+    const perkLocked = pickPhase === PickPhaseVals.PERK && perk > 0;
+    // INITIAL_PICK is the separate starting-bundle phase; the server echoes the picked bundle (picked.length > 0).
+    const bundleLocked = pickPhase === PickPhaseVals.INITIAL_PICK && picked.length > 0;
     // Which bundle was chosen — local index if just picked, else recover it from the picked creatures.
-    const bundleChosenIndex =
-        setupBundleChoice >= 0
-            ? setupBundleChoice
-            : bundleLocked
-              ? initialBundles.findIndex((b) => b[0] === picked[0] && b[1] === picked[1])
-              : -1;
-    const setupBothLocked = perkLocked && bundleLocked;
+    const bundleChosenIndex = bundleLocked
+        ? initialBundles.findIndex((b) => b[0] === picked[0] && b[1] === picked[1])
+        : selectedValue;
 
     let panel: React.ReactNode = <CircularProgress />;
-    if (isCombinedSetup) {
-        // Combined first step: choose a doctrine AND a starting bundle on one screen, each locking independently.
+    if (pickPhase === PickPhaseVals.PERK) {
+        // Doctrine-only phase: choose one scouting doctrine.
         panel = (
-            <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2.5, width: "100%" }}>
-                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
-                    <Chip size="sm" variant="soft" color={perkLocked ? "success" : "primary"}>
-                        1 · Doctrine {perkLocked ? "✓" : ""}
-                    </Chip>
-                    <PerkPanel
-                        disabled={busy || perkLocked}
-                        selected={perkLocked ? perk : selectedValue}
-                        onSelect={(id) => void send(id, () => sendPerk(id))}
-                    />
-                </Box>
-                <Divider sx={{ width: "80%" }} />
-                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
-                    <Chip size="sm" variant="soft" color={bundleLocked ? "success" : "primary"}>
-                        2 · Starting bundle {bundleLocked ? "✓" : ""}
-                    </Chip>
-                    <BundlePanel
-                        bundles={initialBundles}
-                        disabled={busy || bundleLocked}
-                        selected={bundleChosenIndex}
-                        onSelect={(i) => {
-                            setSetupBundleChoice(i);
-                            void send(i, () => pickPair(i));
-                        }}
-                        onInspect={setInspectedId}
-                    />
-                </Box>
-            </Box>
+            <PerkPanel
+                disabled={disabled || perkLocked}
+                selected={perkLocked ? perk : selectedValue}
+                onSelect={(id) => void send(id, () => sendPerk(id))}
+            />
         );
     } else if (pickPhase === PickPhaseVals.INITIAL_PICK) {
-        // Legacy in-flight picks only — new picks fold the bundle into the combined PERK phase above.
+        // Starting-bundle phase: choose one bundle {L1 + L2 + Tier-1 artifact}.
         panel = (
             <BundlePanel
                 bundles={initialBundles}
-                disabled={disabled}
-                selected={selectedValue}
+                disabled={disabled || bundleLocked}
+                selected={bundleChosenIndex}
                 onSelect={(i) => void send(i, () => pickPair(i))}
                 onInspect={setInspectedId}
             />
@@ -1037,7 +1255,7 @@ const StainedGlassWindow: React.FC<StainedGlassProps> = ({ userTeam, opponentLab
                     picked={picked}
                     opponentTaken={opponentTaken}
                     disabled={disabled}
-                    onSelect={(id) => void pickCreature(id)}
+                    onSelect={(id) => setPendingPick(id)}
                     onInspect={setInspectedId}
                 />
             </Box>
@@ -1048,7 +1266,7 @@ const StainedGlassWindow: React.FC<StainedGlassProps> = ({ userTeam, opponentLab
                 disabled={disabled}
                 selected={selectedValue}
                 offered={tier2Offers}
-                onSelect={(id) => void send(id, () => artifact(id, 2))}
+                onSelect={(id) => setPendingArtifact(id)}
             />
         );
     } else if (isHandoff) {
@@ -1142,19 +1360,40 @@ const StainedGlassWindow: React.FC<StainedGlassProps> = ({ userTeam, opponentLab
                 {userTeam ? panel : null}
             </Box>
 
-            {/* In the combined phase both players are actors, so gate the wait on having locked BOTH choices. */}
-            {((!isYourTurn && !isHandoff) || setupBothLocked) && (
+            {/* Each phase is a simultaneous both-teams choice; show "waiting" while the opponent hasn't acted. */}
+            {!isYourTurn && !isHandoff && (
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1, opacity: 0.7 }}>
                     <CircularProgress size="sm" />
                     <Typography level="body-sm">
-                        {setupBothLocked || selectedValue >= 0
-                            ? "Locked in — waiting for your opponent…"
-                            : "Waiting for your opponent…"}
+                        {selectedValue >= 0 ? "Locked in — waiting for your opponent…" : "Waiting for your opponent…"}
                     </Typography>
                 </Box>
             )}
 
             <CreatureDetailPanel creatureId={inspectedId} />
+
+            <PickConfirmModal
+                open={pendingPick > 0 && pickPhase === PickPhaseVals.PICK}
+                creatureId={pendingPick}
+                busy={busy}
+                onConfirm={() => {
+                    const id = pendingPick;
+                    setPendingPick(0);
+                    void pickCreature(id);
+                }}
+                onCancel={() => setPendingPick(0)}
+            />
+            <ArtifactConfirmModal
+                open={pendingArtifact > 0 && pickPhase === PickPhaseVals.ARTIFACT_2}
+                artifactId={pendingArtifact}
+                busy={busy}
+                onConfirm={() => {
+                    const id = pendingArtifact;
+                    setPendingArtifact(0);
+                    void send(id, () => artifact(id, 2));
+                }}
+                onCancel={() => setPendingArtifact(0)}
+            />
 
             {/* Both draft bars share ONE mt:auto wrapper so they stack together at the bottom (two separate
                 mt:auto flex items would split the free space and float the opponent bar mid-screen). */}

--- a/game/core/src/ui/RankedGameView.tsx
+++ b/game/core/src/ui/RankedGameView.tsx
@@ -1892,7 +1892,6 @@ const RankedOpponentPlacementIntel: React.FC<{ snapshot: PlaySnapshot; userTeam:
         return null;
     }
 
-    const knownCount = opponentUnits.filter((unit) => unit.creatureId > 0 && unit.name !== "Unknown").length;
     // The opponent's readiness rides along in the broadcast snapshot's readyPlayerIds, so show it
     // here — when they click "Ready Placement" we reflect it (and they see ours the same way).
     const opponentPlayer = snapshot.players.find((player) => player.team !== userTeam);
@@ -1917,15 +1916,17 @@ const RankedOpponentPlacementIntel: React.FC<{ snapshot: PlaySnapshot; userTeam:
                         {opponentReady ? "Ready" : "Placing…"}
                     </Chip>
                 </Stack>
+                {/* The full roster is always visible during placement (server reveals every opponent unit's
+                    identity) — stack sizes and on-board positions stay hidden, but who they fielded does not. */}
                 <Typography level="body-xs" textColor={hocColors.muted}>
-                    {knownCount}/{opponentUnits.length} known
+                    {opponentUnits.length} units
                 </Typography>
             </Stack>
             <Box
                 sx={{
                     display: "flex",
-                    // Wrap onto multiple rows so every revealed unit stays visible when the right
-                    // sidebar is narrow — a single scrolling row would hide units off-screen.
+                    // Wrap onto multiple rows so every unit stays visible when the right sidebar is narrow —
+                    // a single scrolling row would hide units off-screen.
                     flexWrap: "wrap",
                     gap: 0.6,
                     pb: 0.25,
@@ -1934,35 +1935,36 @@ const RankedOpponentPlacementIntel: React.FC<{ snapshot: PlaySnapshot; userTeam:
                 {opponentUnits.map((unit) => {
                     const known = unit.creatureId > 0 && unit.name !== "Unknown";
                     return (
-                        <Box
-                            key={unit.id}
-                            sx={{
-                                position: "relative",
-                                flex: "0 0 auto",
-                                width: 42,
-                                height: 42,
-                                borderRadius: 6,
-                                border: `1px solid ${known ? "rgba(245,158,11,0.28)" : "rgba(148,163,184,0.18)"}`,
-                                bgcolor: known ? "rgba(245,158,11,0.08)" : "rgba(15,23,42,0.45)",
-                                display: "grid",
-                                placeItems: "center",
-                                overflow: "hidden",
-                            }}
-                        >
+                        <Tooltip key={unit.id} title={known ? unit.name : "Unknown"} placement="top">
                             <Box
-                                component="img"
-                                src={resolveUnitImage(undefined, known ? unit.name : undefined)}
-                                alt=""
                                 sx={{
-                                    width: 36,
-                                    height: 36,
-                                    objectFit: "contain",
-                                    // Revealed (known) units show their real creature art in full color;
-                                    // still-hidden units stay a dark grayscale silhouette.
-                                    filter: known ? "none" : "grayscale(1) brightness(0.42) opacity(0.55)",
+                                    position: "relative",
+                                    flex: "0 0 auto",
+                                    width: 42,
+                                    height: 42,
+                                    borderRadius: 6,
+                                    border: `1px solid ${known ? "rgba(245,158,11,0.28)" : "rgba(148,163,184,0.18)"}`,
+                                    bgcolor: known ? "rgba(245,158,11,0.08)" : "rgba(15,23,42,0.45)",
+                                    display: "grid",
+                                    placeItems: "center",
+                                    overflow: "hidden",
                                 }}
-                            />
-                        </Box>
+                            >
+                                <Box
+                                    component="img"
+                                    src={resolveUnitImage(undefined, known ? unit.name : undefined)}
+                                    alt=""
+                                    sx={{
+                                        width: 36,
+                                        height: 36,
+                                        objectFit: "contain",
+                                        // Full roster is visible in color during placement; the grayscale
+                                        // silhouette is only a fallback for legacy/edge-case unknown units.
+                                        filter: known ? "none" : "grayscale(1) brightness(0.42) opacity(0.55)",
+                                    }}
+                                />
+                            </Box>
+                        </Tooltip>
                     );
                 })}
             </Box>

--- a/game/core/src/ui/context/PickBanContext.tsx
+++ b/game/core/src/ui/context/PickBanContext.tsx
@@ -17,6 +17,7 @@ export const PickBanEventProvider: React.FC<{
     const [banned, setBanned] = useState<number[]>([]);
     const [picked, setPicked] = useState<number[]>([]);
     const [opponentPicked, setOpponentPicked] = useState<number[]>([]);
+    const [watchedSlots, setWatchedSlots] = useState<number[]>([]);
     const [isYourTurn, setIsYourTurn] = useState<boolean | null>(null);
     const [isAbandoned, setIsAbandoned] = useState<boolean | null>(null);
     const [pickPhase, setPickPhase] = useState<number>(-1);
@@ -64,6 +65,7 @@ export const PickBanEventProvider: React.FC<{
             setBanned(event.b);
             setPicked(event.p);
             setOpponentPicked(event.op);
+            setWatchedSlots(event.ws ?? []);
             setPickPhase(event.pp);
             setIsYourTurn(event.a.includes(userTeam));
             setIsAbandoned(event.ia);
@@ -105,6 +107,7 @@ export const PickBanEventProvider: React.FC<{
             banned,
             picked,
             opponentPicked,
+            watchedSlots,
             isYourTurn,
             isAbandoned,
             pickPhase,
@@ -126,6 +129,7 @@ export const PickBanEventProvider: React.FC<{
             banned,
             picked,
             opponentPicked,
+            watchedSlots,
             isYourTurn,
             isAbandoned,
             pickPhase,

--- a/game/core/src/ui/context/PickBanContextDefs.ts
+++ b/game/core/src/ui/context/PickBanContextDefs.ts
@@ -22,6 +22,8 @@ export interface IPickPhaseEventData {
     b: number[];
     // opponent picked
     op: number[];
+    // opponent slot indices this player's doctrine watches (into the opponent's level-sorted picked array).
+    ws: number[];
     // time remaining
     t: number;
     // reveals remanining
@@ -44,6 +46,8 @@ export interface PickBanContextType {
     banned: number[];
     picked: number[];
     opponentPicked: number[];
+    // Opponent slot indices (0..5, into the opponent's level-sorted army) this player's doctrine watches.
+    watchedSlots: number[];
     isYourTurn: boolean | null;
     isAbandoned: boolean | null;
     pickPhase: number;
@@ -74,6 +78,7 @@ export const PickBanContext = createContext<PickBanContextType>({
     banned: [],
     picked: [],
     opponentPicked: [],
+    watchedSlots: [],
     isYourTurn: null,
     isAbandoned: null,
     pickPhase: -1,


### PR DESCRIPTION
## Summary

Companion client PR to o1dstaRs/heroes-of-crypto-server#38.

- **Split the combined PERK screen** into two separate stages: PERK (doctrine only) → INITIAL_PICK/BUNDLE (starting bundle). Stepper, phase hints, and action text updated.
- **Dota-style ban strike**: banned creatures show a crimson diagonal band. The grayscale filter was moved off the portrait wrapper onto the `<img>` so the red strike stays red (it was being desaturated by the parent's `filter: grayscale(1)`).
- **Confirm modals**: clicking a creature (PICK) or an artifact (ARTIFACT_2) opens a centered preview (portrait/icon + stats/description) with Confirm/Cancel buttons instead of committing instantly.
- **Fixed opponent slot mapping**: `OpponentDraftBar` builds the 6 fixed slots directly from the slot-aligned reveal array — each scouted creature stays at its true positional slot (bundle vs. separately-picked ordering preserved).
- **Opponent army on the board**: during placement the opponent's full roster is laid out in a single horizontal line across their board edge. Already-drawn revealed-opponent units are preserved across placement rebuilds so they don't flicker/re-spawn while the player drags their own units.
- **Opponent roster panel**: `RankedOpponentPlacementIntel` shows the full opponent roster in color with tooltips (was silhouettes for unknown units).

## Files
- `game/core/src/ui/PickAndBan/index.tsx` — stage split, ban strike, confirm modals, slot mapping
- `game/core/src/ui/RankedGameView.tsx` — full-roster opponent panel
- `game/core/src/scenes/RankedPlayScene.ts` — line layout for revealed opponent units
- `game/core/src/scenes/Sandbox.ts` — preserve revealed-opponent units across placement rebuilds
- `game/core/src/ui/context/PickBanContext{,Defs}.tsx` — propagate `ws` (watched slot indices)

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bunx eslint` on changed files — clean
- [ ] Manual: PERK→Bundle staging, ban strike color, confirm modals, opponent army on board at placement

Depends on the server PR for the phase-split protocol and roster/slot changes.