### PR TITLE
fix(board): drop the enemy-turn frame; fix(e2e): start the client in dev mode

### DIFF
--- a/.claude/skills/heroes-e2e/scripts/hoc-e2e.sh
+++ b/.claude/skills/heroes-e2e/scripts/hoc-e2e.sh
@@ -74,7 +74,10 @@ ensure_monitor() {
 ensure_client() {
     if port_busy "$CLIENT_PORT"; then echo "client: already on :$CLIENT_PORT"; return; fi
     echo "client: starting (vite --port $CLIENT_PORT --strictPort) -> $CLIENT_LOG"
-    (cd "$CLIENT_DIR/game/core" && nohup bun x vite --port "$CLIENT_PORT" --strictPort >"$CLIENT_LOG" 2>&1 &)
+    # NODE_ENV=development is what `npm start` sets via cross-env, and the app needs it: without it the
+    # bundle takes the production path, the dev `?e2eEmail=`/`?e2ePlayerId=` auto-login never runs, and
+    # React mounts nothing at all — a blank page on every URL, with no error in the console or vite log.
+    (cd "$CLIENT_DIR/game/core" && NODE_ENV=development nohup bun x vite --port "$CLIENT_PORT" --strictPort >"$CLIENT_LOG" 2>&1 &)
     wait_for "port_busy $CLIENT_PORT" 60 || { echo "client failed; see $CLIENT_LOG"; tail -20 "$CLIENT_LOG"; exit 1; }
     echo "client: up on :$CLIENT_PORT"
 }

--- a/game/core/src/scenes/SandboxDrawer.ts
+++ b/game/core/src/scenes/SandboxDrawer.ts
@@ -97,10 +97,9 @@ export class SandboxDrawer {
         // On the enemy's turn the movement highlight switches from white to red.
         const movementColor = ctx.enemyTurnView ? ENEMY_TURN_HIGHLIGHT_COLOR : 0xffffff;
 
-        // Glowing red border around the board while it is the enemy's turn.
-        if (ctx.enemyTurnView) {
-            SandboxDrawer.drawEnemyTurnBorder(g, gs, hoverGlowPhase);
-        }
+        // The board no longer gets a red frame on the enemy's turn — the turn card already says "Enemy
+        // turn" in red, and the frame fought with the board art. The red movement highlight above still
+        // carries the cue on the board itself.
 
         // 0. Hovered Move Range (Placement Phase)
         // 0. Hovered Move Range (Placement Phase) - Animated Dots
@@ -285,38 +284,6 @@ export class SandboxDrawer {
                 hoverManager.drawHoveredUnitHighlight(g);
             }
         }
-    }
-    /**
-     * Glowing red rectangle hugging the board edges, breathing with the shared hover-glow phase.
-     * Drawn while it is the enemy's turn so the viewer always has a clear "not your turn" cue even
-     * when no unit/move is highlighted.
-     */
-    private static drawEnemyTurnBorder(g: Graphics, gs: GridSettings, phase: number): void {
-        const minX = gs.getMinX();
-        const minY = gs.getMinY();
-        const width = gs.getMaxX() - minX;
-        const height = gs.getMaxY() - minY;
-        const cell = gs.getCellSize();
-        const pulse = (Math.sin(phase * 2) + 1) / 2; // 0..1 breathing
-
-        // Soft outer glow: several expanding strokes fading out as they move away from the edge.
-        const glowLayers = 6;
-        for (let i = glowLayers; i >= 1; i--) {
-            const spread = cell * 0.14 * i * (0.85 + 0.3 * pulse);
-            const alpha = (0.12 + 0.06 * pulse) * (1 - i / (glowLayers + 1));
-            g.rect(minX - spread, minY - spread, width + spread * 2, height + spread * 2).stroke({
-                width: Math.max(2, cell * 0.06),
-                color: ENEMY_TURN_HIGHLIGHT_COLOR,
-                alpha,
-            });
-        }
-
-        // Crisp inner border line sitting right on the board edge.
-        g.rect(minX, minY, width, height).stroke({
-            width: Math.max(2, cell * 0.05),
-            color: ENEMY_TURN_HIGHLIGHT_COLOR,
-            alpha: 0.55 + 0.25 * pulse,
-        });
     }
     private static drawAuraAndAttackRanges(
         g: Graphics,


### PR DESCRIPTION
Two unrelated one-liners that surfaced in the same session.

## The red frame around the board
`SandboxDrawer.drawEnemyTurnBorder` painted a pulsing red rectangle around the entire board on the opponent's turn — six expanding glow passes plus a crisp inner line, breathing on the shared hover-glow phase. It competed with the board art for attention.

The cue is not lost. "Enemy turn" still reads in red on the turn card, and the movement highlight still switches from white to red on the board itself.

## The e2e client mounted nothing
`hoc-e2e.sh` launched the client with a bare `bun x vite`, without the `NODE_ENV=development` that `npm start` sets via `cross-env`. Without it the bundle takes the production path, the dev `?e2eEmail=` / `?e2ePlayerId=` auto-login never runs, and React mounts nothing.

The symptom is nasty to diagnose: a blank page on **every** URL, with vite reporting a clean startup and no error in the browser console or the server log. Worth the comment left at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)