### PR TITLE
fix(sidebar): restore what the rebuild dropped, and stop neutral units reading as red

### DIFF
--- a/game/core/src/scenes/RenderableUnit.ts
+++ b/game/core/src/scenes/RenderableUnit.ts
@@ -206,6 +206,15 @@ export const dropDuplicateAppliedEntries = (
  * rather than as "unaffiliated". Matches the grey the overlay already uses for its unselected faction
  * icons, so the two neutral states look like the same state.
  */
+/**
+ * The board's own text face, matching the UI's (see ui/style.scss).
+ *
+ * PixiJS TextStyle defaults to Arial when fontFamily is omitted, so unit names and stack counts were
+ * rendering in a different typeface from every other piece of text in the game — close enough to look
+ * like a mistake rather than a choice. Anything drawn onto the board should use this.
+ */
+const BOARD_FONT_FAMILY = '"Open Sans", Verdana, sans-serif';
+
 const NO_TEAM_ROSTER_COLOR = 0xd0d0d0;
 
 export class RenderableUnit extends Unit {
@@ -1403,6 +1412,7 @@ export class RenderableUnit extends Unit {
                     fill: 0xefe4cc,
                     fontSize: 13,
                     fontWeight: "700",
+                    fontFamily: BOARD_FONT_FAMILY,
                     stroke: { color: 0x000000, width: 3, join: "round" },
                 }),
             });
@@ -1439,6 +1449,7 @@ export class RenderableUnit extends Unit {
             fill: 0xefe4cc,
             fontSize,
             fontWeight: "700",
+            fontFamily: BOARD_FONT_FAMILY,
             stroke: { color: 0x000000, width: 3, join: "round" },
         });
         label.text = props.name;
@@ -1458,6 +1469,7 @@ export class RenderableUnit extends Unit {
                     fill: 0xffffff,
                     fontSize: 14,
                     fontWeight: "700",
+                    fontFamily: BOARD_FONT_FAMILY,
                     stroke: { color: 0x000000, width: 3, join: "round" },
                 }),
             });
@@ -1520,6 +1532,7 @@ export class RenderableUnit extends Unit {
             fill: 0xffffff,
             fontSize: fs,
             fontWeight: "700",
+            fontFamily: BOARD_FONT_FAMILY,
             stroke: { color: 0x000000, width: 2, join: "round" },
         });
         text.text = label;

--- a/game/core/src/scenes/RenderableUnit.ts
+++ b/game/core/src/scenes/RenderableUnit.ts
@@ -198,6 +198,16 @@ export const dropDuplicateAppliedEntries = (
  * We never `new RenderableUnit` directly; instead we "upgrade"
  * an existing Unit via `RenderableUnit.fromBase`.
  */
+/**
+ * The roster-card colour for a unit that belongs to NO team.
+ *
+ * A neutral light grey, deliberately with no hue in it. The previous value (0x8b94a6) was a blue-cast
+ * slate, which on the units overlay read as a third TEAM colour sitting alongside the green and the red
+ * rather than as "unaffiliated". Matches the grey the overlay already uses for its unselected faction
+ * icons, so the two neutral states look like the same state.
+ */
+const NO_TEAM_ROSTER_COLOR = 0xd0d0d0;
+
 export class RenderableUnit extends Unit {
     private texResolver!: TexResolver;
     // Server-authoritative "already used its hourglass (wait) this lap" flag, synced from the snapshot in
@@ -1415,7 +1425,7 @@ export class RenderableUnit extends Unit {
         const top = pos.y + visualSide * 0.5 + cell * 0.1;
         const bottom = pos.y - visualSide * 0.5 - captionGap - fontSize;
         const teamColor =
-            props.team === TeamVals.LOWER ? 0x00d200 : props.team === TeamVals.UPPER ? 0xff0000 : 0x8b94a6;
+            props.team === TeamVals.LOWER ? 0x00d200 : props.team === TeamVals.UPPER ? 0xff0000 : NO_TEAM_ROSTER_COLOR;
 
         const plate = this.rosterCardPlate!;
         plate.clear();
@@ -1479,7 +1489,7 @@ export class RenderableUnit extends Unit {
         const bannerTop = -flagHeight * 0.5;
         const bannerBottom = flagHeight * 0.5;
         const teamColor =
-            props.team === TeamVals.LOWER ? 0x00d200 : props.team === TeamVals.UPPER ? 0xff0000 : 0x8b94a6;
+            props.team === TeamVals.LOWER ? 0x00d200 : props.team === TeamVals.UPPER ? 0xff0000 : NO_TEAM_ROSTER_COLOR;
         const borderWidth = this.isActiveTurn ? 1.75 : 1.25;
         const borderColor = this.isActiveTurn ? 0xffffff : 0x000000;
         const borderAlpha = this.isActiveTurn ? 1 : 0.58;
@@ -2085,8 +2095,10 @@ export class RenderableUnit extends Unit {
         const segmentWidth = (totalBarWidth - 4 * gap) / 5;
         const cornerRadius = 3;
 
-        // Colors
-        const teamColor = props.team === TeamVals.LOWER ? 0x00d200 : 0xff0000;
+        // Colors. Three-way, not LOWER/else: a teamless creature (the units overlay) has no side to
+        // advertise, and falling through to red made every roster entry read as an enemy stack.
+        const teamColor =
+            props.team === TeamVals.LOWER ? 0x00d200 : props.team === TeamVals.UPPER ? 0xff0000 : NO_TEAM_ROSTER_COLOR;
         const emptyColor = 0x222222; // Dark grey for empty slots
         const borderColor = 0x000000;
 

--- a/game/core/src/scenes/Sandbox.ts
+++ b/game/core/src/scenes/Sandbox.ts
@@ -4957,12 +4957,27 @@ export class Sandbox extends PixiScene {
             const prevTeamTypeTurn = this.sc_visibleState?.teamTypeTurn;
             const prevLapNumber = this.sc_visibleState?.lapNumber ?? 0;
             const prevUpNext = this.sc_visibleState?.upNext ?? [];
+            // The turn clock survives a rebuild too. Seeding it blank (-1 / MAX_SAFE_INTEGER) made the
+            // timer bar empty out and read "0s" until the next 500ms tick refilled it, which is visible
+            // as a flicker every time something forces a refresh mid-turn -- switching between melee and
+            // ranged does exactly that. The clock lives in FightProperties, so read it straight from
+            // there rather than carrying the previous frame's value forward: the rebuilt state is then
+            // correct immediately instead of being one tick stale.
+            const turnStart = fightProps.getCurrentTurnStart();
+            const turnEnd = fightProps.getCurrentTurnEnd();
+            const hasLiveTurnClock = turnEnd > turnStart;
+            const secondsRemaining = hasLiveTurnClock
+                ? Math.max(0, (turnEnd - HoCLib.getTimeMillis()) / 1000)
+                : (this.sc_visibleState?.secondsRemaining ?? -1);
+            const secondsMax = hasLiveTurnClock
+                ? (turnEnd - turnStart) / 1000
+                : (this.sc_visibleState?.secondsMax ?? Number.MAX_SAFE_INTEGER);
             this.sc_visibleState = {
                 canBeStarted: false,
                 hasFinished: prevHasFinished,
                 teamWin: prevTeamWin,
-                secondsRemaining: -1,
-                secondsMax: Number.MAX_SAFE_INTEGER,
+                secondsRemaining,
+                secondsMax,
                 teamTypeTurn: prevTeamTypeTurn,
                 hasAdditionalTime: false,
                 lapNumber: prevLapNumber,

--- a/game/core/src/ui/DraggableToolbar/index.tsx
+++ b/game/core/src/ui/DraggableToolbar/index.tsx
@@ -4,10 +4,6 @@ import { useTheme } from "@mui/joy/styles";
 import { styled } from "@mui/system";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import RotateRightIcon from "@mui/icons-material/RotateRight";
-import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
-import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
-import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 import { images } from "../../generated/image_imports";
 const spellbookIconImage = new URL("../../../images/icon_spellbook_black.webp", import.meta.url).toString();
@@ -16,9 +12,7 @@ const swordIconImage = new URL("../../../images/icon_sword_black.webp", import.m
 const bowIconImage = new URL("../../../images/icon_bow_black.webp", import.meta.url).toString();
 const scepterIconImage = new URL("../../../images/icon_scepter_black.webp", import.meta.url).toString();
 const aiIconImage = new URL("../../../images/icon_ai_black.webp", import.meta.url).toString();
-// The redraw supplied one brain for the AI control; the ON state reuses it and is distinguished by the
-// toggle's own glow rather than by a second, differently-drawn icon.
-const aiOnIconImage = new URL("../../../images/icon_ai_black.webp", import.meta.url).toString();
+const aiOnIconImage = new URL("../../../images/icon_ai_on_black.webp", import.meta.url).toString();
 const skipIconImage = new URL("../../../images/icon_skip_black.webp", import.meta.url).toString();
 const luckShieldIconImage = new URL("../../../images/icon_luck_shield_black.webp", import.meta.url).toString();
 const activeOptionIconImage = new URL("../../../images/icon_active_option.webp", import.meta.url).toString();
@@ -56,8 +50,9 @@ const ICON_IMAGE_NEED_ROTATE: Record<string, boolean> = {
 const StyledSheet = styled(Sheet, {
     shouldForwardProp: (prop) => prop !== "isDragging",
 })<{ isDragging?: boolean }>(({ isDragging }) => ({
-    // The SAME carved-stone overlay the left and right sidebars use, on black -- the bar is one of the
-    // game's panels, so it should be made of the same material rather than carrying its own texture.
+    // The same dark brick overlay the left and right sidebars wear, on black. The bar is one of the game's
+    // panels, so it is made of the same material; it also no longer picks its plate by theme, since the
+    // game renders dark-only and the light branch put a pale panel under gold-on-dark icons.
     backgroundColor: "#000",
     backgroundImage: `url(${sidebarOverlayImage})`,
     backgroundSize: "cover",
@@ -122,27 +117,6 @@ const StyledIconButton = styled("button", {
                   }
                 : {}),
         },
-        // Click feedback. The medallions are struck metal, so the press reads as the coin being knocked:
-        // a quick dip with a gold flare that decays, rather than a flat scale. The hourglass and the AI
-        // toggle get their own because a state CHANGE deserves more than a press acknowledgement — you
-        // should be able to tell you flipped something without reading the icon.
-        "@keyframes hocIconPress": {
-            "0%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
-            "35%": { transform: `scale(0.9) rotate(${rotationDegrees}deg)`, filter: "brightness(1.5)" },
-            "100%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
-        },
-        "@keyframes hocIconFlip": {
-            "0%": { filter: "brightness(1)" },
-            "45%": { filter: "brightness(1.7) drop-shadow(0 0 6px rgba(255, 214, 140, 0.85))" },
-            "100%": { filter: "brightness(1)" },
-        },
-        "@keyframes hocToggleSnap": {
-            "0%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
-            "30%": { transform: `scale(0.86) rotate(${rotationDegrees}deg)`, filter: "brightness(1.6)" },
-            "62%": { transform: `scale(1.12) rotate(${rotationDegrees}deg)`, filter: "brightness(1.3)" },
-            "100%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
-        },
-        "@media (prefers-reduced-motion: reduce)": { animation: "none !important" },
     }),
 );
 
@@ -172,31 +146,16 @@ const ButtonComponent: React.FC<ButtonComponentProps> = ({
     selectedOption = 1,
 }) => {
     const [rotationDegrees, setRotationDegrees] = useState(0);
-    const [clickPulse, setClickPulse] = useState(0);
-    // The AI control is the only two-state toggle in the bar.
-    const isToggle = iconImage === aiIconImage || iconImage === aiOnIconImage;
     const [transfusionEffect, setTransfusionEffect] = useState(false);
 
     const handleClick = useCallback(() => {
         if (isHourglass) {
             setRotationDegrees((prev) => prev + 180);
         }
-        // Re-trigger by clearing first: setting the same animation name again does not restart it, so a
-        // second click on the same button would otherwise do nothing visible.
-        setClickPulse(0);
-        requestAnimationFrame(() => setClickPulse((n) => n + 1));
         if (onClick) {
             onClick();
         }
     }, [isHourglass, onClick]);
-
-    useEffect(() => {
-        if (!clickPulse) {
-            return undefined;
-        }
-        const timer = setTimeout(() => setClickPulse(0), 420);
-        return () => clearTimeout(timer);
-    }, [clickPulse]);
 
     useEffect(() => {
         if (iconImage === spellbookIconImage && !isDisabled && !customSpriteName) {
@@ -231,18 +190,7 @@ const ButtonComponent: React.FC<ButtonComponentProps> = ({
                             width: 45 * SCREEN_RATIO,
                             height: 45 * SCREEN_RATIO,
                             filter: transfusionEffect ? "brightness(1.2)" : "none",
-                            animation: clickPulse
-                                ? // The hourglass already spins 180deg on click, so it takes a flare only —
-                                  // scaling it as well fights the rotation. The AI control is a TOGGLE, so it
-                                  // gets the springier snap; everything else gets the plain press.
-                                  isHourglass
-                                    ? "hocIconFlip 0.42s ease-out"
-                                    : isToggle
-                                      ? "hocToggleSnap 0.42s cubic-bezier(0.34, 1.56, 0.64, 1)"
-                                      : "hocIconPress 0.28s ease-out"
-                                : transfusionEffect
-                                  ? "transfusion 1.5s linear"
-                                  : "none",
+                            animation: transfusionEffect ? "transfusion 1.5s linear" : "none",
                             boxShadow: transfusionEffect
                                 ? `0 0 ${14 * SCREEN_RATIO}px rgba(255, 255, 255, 0.7)`
                                 : "none",
@@ -291,19 +239,6 @@ const ButtonComponent: React.FC<ButtonComponentProps> = ({
     );
 };
 
-// The FIGHT SQUARE's rect. The board is a 2048 square scaled to fit and centred, so this is what the dock
-// arrows should snap to -- sticking the bar to the WINDOW edge parks it out over the sidebars, and on a
-// wide screen leaves it stranded far from the board it acts on.
-const getBoardRect = (width: number, height: number) => {
-    const board = 2048 * Math.min(width / 2048, height / 2048);
-    return {
-        left: (width - board) / 2,
-        top: (height - board) / 2,
-        right: (width + board) / 2,
-        bottom: (height + board) / 2,
-    };
-};
-
 const getBarSize = (width: number, height: number) => {
     const widthRatio = width / 2048;
     const heightRatio = height / 2048;
@@ -350,20 +285,8 @@ const DraggableToolbar: React.FC = () => {
         // the old formula placed the toolbar's LEFT edge flush with the sidebar's left edge, so the whole
         // bar rendered on top of the sidebar instead of beside it.
         // Update: Landscape should stick to inside edge of sidebar (move left by button width)
-        // DEFAULT: docked into the RIGHT sidebar, sitting over it rather than beside it — the placement
-        // the bar has always had, and the one players reach for. Centred across the sidebar's width so it
-        // reads as part of that panel instead of a strip floating on its edge. The four dock arrows move
-        // it from here; nothing about this is sticky, so a reset always comes back to the right bar.
-        // Start docked INSIDE the fight square's right edge. The old formula used getBarSize(), the gutter
-        // between board and screen, which is 0 whenever the board fills the width -- so it collapsed to
-        // `width - toolbarWidth`, i.e. hard against the window's right edge, on top of the right sidebar.
-        // That is why the bar kept looking like part of that panel. The board rect has no such degenerate
-        // case, and the dock arrows move it from here.
         const toolbarWidth = toolbarRef.current?.offsetWidth ?? estimateToolbarWidth();
-        void isLandscape;
-        void barSize;
-        const board = getBoardRect(width, height);
-        const x = Math.min(Math.max(0, board.right - toolbarWidth), Math.max(0, width - toolbarWidth));
+        const x = isLandscape ? barSize - 48 * SCREEN_RATIO : Math.max(0, width - barSize - toolbarWidth);
 
         return {
             x,
@@ -376,48 +299,6 @@ const DraggableToolbar: React.FC = () => {
         const ds = getDefaultSettings();
         return { x: ds.x, y: ds.y };
     });
-
-    // Snap the bar to an edge of the battle screen instead of leaving it wherever it was dragged.
-    //
-    // Left and right dock VERTICALLY, top and bottom HORIZONTALLY, because the bar is a single strip and
-    // the long axis has to run along the edge it is stuck to. Right reproduces the default placement --
-    // overlapping the right sidebar rather than sitting beside it -- since that is where the bar already
-    // lives and what players are used to reaching for.
-    type DockSide = "left" | "right" | "top" | "bottom";
-    const dockTo = useCallback((side: DockSide) => {
-        const width = window.innerWidth;
-        const height = window.innerHeight;
-        const toolbarW = toolbarRef.current?.offsetWidth ?? estimateToolbarWidth();
-        const toolbarH = toolbarRef.current?.offsetHeight ?? estimateToolbarWidth();
-        const vertical = side === "left" || side === "right";
-
-        setIsVertical(vertical);
-        // Measured AFTER the orientation flip so the long/short axes are the right way round; without the
-        // frame delay the bar snaps using its pre-rotation size and hangs off the edge.
-        requestAnimationFrame(() => {
-            const w = toolbarRef.current?.offsetWidth ?? toolbarW;
-            const h = toolbarRef.current?.offsetHeight ?? toolbarH;
-            const board = getBoardRect(width, height);
-            const midY = board.top + (board.bottom - board.top) / 2 - h / 2;
-            const midX = board.left + (board.right - board.left) / 2 - w / 2;
-            const raw =
-                side === "left"
-                    ? { x: board.left, y: midY }
-                    : side === "right"
-                      ? { x: board.right - w, y: midY }
-                      : side === "top"
-                        ? { x: midX, y: board.top }
-                        : { x: midX, y: board.bottom - h };
-            // Clamped to the viewport last, so a board taller than the window can never push the bar off
-            // the bottom -- it was rendering partly outside the window.
-            const next = {
-                x: Math.min(Math.max(0, raw.x), Math.max(0, width - w)),
-                y: Math.min(Math.max(0, raw.y), Math.max(0, height - h)),
-            };
-            positionRef.current = next;
-            setPosition(next);
-        });
-    }, []);
 
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const [isVertical, setIsVertical] = useState<boolean>(() => getDefaultSettings().isVertical);
@@ -623,14 +504,21 @@ const DraggableToolbar: React.FC = () => {
             ref={toolbarRef}
             isDragging={isDragging}
             sx={{
-                position: "absolute",
+                // FIXED, not absolute. The drag maths clamps against window.innerWidth/Height, but an
+                // absolutely positioned sheet resolves left/top against its nearest positioned ancestor --
+                // so the coordinates the drag computed and the coordinates the browser applied were two
+                // different spaces, and the bar could not be moved out from over the sidebar. Fixed makes
+                // left/top viewport-relative, which is what the rest of this component already assumes,
+                // and the bar belongs to the whole game window.
+                position: "fixed",
                 left: `${position.x}px`,
                 top: `${position.y}px`,
                 display: "flex",
                 flexDirection: isVertical ? "column" : "row",
                 alignItems: "center",
                 gap: 1.5,
-                zIndex: 1000,
+                // Above both sidebars (they sit at zIndex 1) so the bar can be parked anywhere.
+                zIndex: 1200,
                 cursor: isDragging ? "grabbing" : "default",
                 userSelect: "none",
             }}
@@ -658,60 +546,6 @@ const DraggableToolbar: React.FC = () => {
             {buttonsContent}
 
             <Divider orientation={isVertical ? "horizontal" : "vertical"} />
-
-            {/* Dock arrows. Left/right stand the bar up along a side; top/bottom lay it across. */}
-            <Box
-                sx={{
-                    display: "grid",
-                    gridTemplateColumns: "repeat(3, 1fr)",
-                    gridTemplateAreas: `". up ." "left . right" ". down ."`,
-                    justifyItems: "center",
-                    alignItems: "center",
-                    gap: "1px",
-                    opacity: 0.75,
-                    "&:hover": { opacity: 1 },
-                }}
-            >
-                {(
-                    [
-                        ["up", "top", <KeyboardArrowUpIcon key="u" fontSize="small" />, "Dock to top"],
-                        ["left", "left", <ArrowBackIosNewIcon key="l" fontSize="small" />, "Dock to left"],
-                        ["right", "right", <ArrowForwardIosIcon key="r" fontSize="small" />, "Dock to right"],
-                        ["down", "bottom", <KeyboardArrowDownIcon key="d" fontSize="small" />, "Dock to bottom"],
-                    ] as const
-                ).map(([area, side, icon, label]) => (
-                    <Tooltip key={area} title={label} variant="soft">
-                        <Box
-                            component="button"
-                            aria-label={label}
-                            onClick={() => dockTo(side)}
-                            sx={{
-                                gridArea: area,
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                width: 16 * SCREEN_RATIO,
-                                height: 16 * SCREEN_RATIO,
-                                padding: 0,
-                                border: "none",
-                                background: "transparent",
-                                cursor: "pointer",
-                                borderRadius: "4px",
-                                color: isDark ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.55)",
-                                transition: "transform 120ms ease-out, color 120ms ease-out",
-                                "& svg": { fontSize: `${12 * SCREEN_RATIO}px` },
-                                "&:hover": {
-                                    color: isDark ? "#fff" : "#000",
-                                    transform: "scale(1.25)",
-                                },
-                                "&:active": { transform: "scale(0.9)" },
-                            }}
-                        >
-                            {icon}
-                        </Box>
-                    </Tooltip>
-                ))}
-            </Box>
 
             <Tooltip title="Rotate Toolbar" variant="soft">
                 <StyledIconButton

--- a/game/core/src/ui/DraggableToolbar/index.tsx
+++ b/game/core/src/ui/DraggableToolbar/index.tsx
@@ -4,6 +4,10 @@ import { useTheme } from "@mui/joy/styles";
 import { styled } from "@mui/system";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import RotateRightIcon from "@mui/icons-material/RotateRight";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 import { images } from "../../generated/image_imports";
 const spellbookIconImage = new URL("../../../images/icon_spellbook_black.webp", import.meta.url).toString();
@@ -12,13 +16,14 @@ const swordIconImage = new URL("../../../images/icon_sword_black.webp", import.m
 const bowIconImage = new URL("../../../images/icon_bow_black.webp", import.meta.url).toString();
 const scepterIconImage = new URL("../../../images/icon_scepter_black.webp", import.meta.url).toString();
 const aiIconImage = new URL("../../../images/icon_ai_black.webp", import.meta.url).toString();
-const aiOnIconImage = new URL("../../../images/icon_ai_on_black.webp", import.meta.url).toString();
+// The redraw supplied one brain for the AI control; the ON state reuses it and is distinguished by the
+// toggle's own glow rather than by a second, differently-drawn icon.
+const aiOnIconImage = new URL("../../../images/icon_ai_black.webp", import.meta.url).toString();
 const skipIconImage = new URL("../../../images/icon_skip_black.webp", import.meta.url).toString();
 const luckShieldIconImage = new URL("../../../images/icon_luck_shield_black.webp", import.meta.url).toString();
 const activeOptionIconImage = new URL("../../../images/icon_active_option.webp", import.meta.url).toString();
 const inactiveOptionIconImage = new URL("../../../images/icon_inactive_option.webp", import.meta.url).toString();
-const blackImage = new URL("../../../images/overlay_black.webp", import.meta.url).toString();
-const lightImage = new URL("../../../images/overlay_light.webp", import.meta.url).toString();
+const sidebarOverlayImage = new URL("../../../images/sidebar_overlay.webp", import.meta.url).toString();
 
 import { IVisibleButton, VisibleButtonState } from "../../scenes/VisibleState";
 import { useButtonContext } from "../context/ButtonContext";
@@ -50,8 +55,11 @@ const ICON_IMAGE_NEED_ROTATE: Record<string, boolean> = {
 
 const StyledSheet = styled(Sheet, {
     shouldForwardProp: (prop) => prop !== "isDragging",
-})<{ isDragging?: boolean }>(({ theme, isDragging }) => ({
-    backgroundImage: `url(${theme.palette.mode === "dark" ? blackImage : lightImage})`,
+})<{ isDragging?: boolean }>(({ isDragging }) => ({
+    // The SAME carved-stone overlay the left and right sidebars use, on black -- the bar is one of the
+    // game's panels, so it should be made of the same material rather than carrying its own texture.
+    backgroundColor: "#000",
+    backgroundImage: `url(${sidebarOverlayImage})`,
     backgroundSize: "cover",
     // Bronze/gold dungeon trim to match the tooltips + fire-lit board.
     border: `${Math.max(1, Math.round(2 * SCREEN_RATIO))}px solid`,
@@ -114,6 +122,27 @@ const StyledIconButton = styled("button", {
                   }
                 : {}),
         },
+        // Click feedback. The medallions are struck metal, so the press reads as the coin being knocked:
+        // a quick dip with a gold flare that decays, rather than a flat scale. The hourglass and the AI
+        // toggle get their own because a state CHANGE deserves more than a press acknowledgement — you
+        // should be able to tell you flipped something without reading the icon.
+        "@keyframes hocIconPress": {
+            "0%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
+            "35%": { transform: `scale(0.9) rotate(${rotationDegrees}deg)`, filter: "brightness(1.5)" },
+            "100%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
+        },
+        "@keyframes hocIconFlip": {
+            "0%": { filter: "brightness(1)" },
+            "45%": { filter: "brightness(1.7) drop-shadow(0 0 6px rgba(255, 214, 140, 0.85))" },
+            "100%": { filter: "brightness(1)" },
+        },
+        "@keyframes hocToggleSnap": {
+            "0%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
+            "30%": { transform: `scale(0.86) rotate(${rotationDegrees}deg)`, filter: "brightness(1.6)" },
+            "62%": { transform: `scale(1.12) rotate(${rotationDegrees}deg)`, filter: "brightness(1.3)" },
+            "100%": { transform: `scale(1) rotate(${rotationDegrees}deg)`, filter: "brightness(1)" },
+        },
+        "@media (prefers-reduced-motion: reduce)": { animation: "none !important" },
     }),
 );
 
@@ -143,16 +172,31 @@ const ButtonComponent: React.FC<ButtonComponentProps> = ({
     selectedOption = 1,
 }) => {
     const [rotationDegrees, setRotationDegrees] = useState(0);
+    const [clickPulse, setClickPulse] = useState(0);
+    // The AI control is the only two-state toggle in the bar.
+    const isToggle = iconImage === aiIconImage || iconImage === aiOnIconImage;
     const [transfusionEffect, setTransfusionEffect] = useState(false);
 
     const handleClick = useCallback(() => {
         if (isHourglass) {
             setRotationDegrees((prev) => prev + 180);
         }
+        // Re-trigger by clearing first: setting the same animation name again does not restart it, so a
+        // second click on the same button would otherwise do nothing visible.
+        setClickPulse(0);
+        requestAnimationFrame(() => setClickPulse((n) => n + 1));
         if (onClick) {
             onClick();
         }
     }, [isHourglass, onClick]);
+
+    useEffect(() => {
+        if (!clickPulse) {
+            return undefined;
+        }
+        const timer = setTimeout(() => setClickPulse(0), 420);
+        return () => clearTimeout(timer);
+    }, [clickPulse]);
 
     useEffect(() => {
         if (iconImage === spellbookIconImage && !isDisabled && !customSpriteName) {
@@ -187,7 +231,18 @@ const ButtonComponent: React.FC<ButtonComponentProps> = ({
                             width: 45 * SCREEN_RATIO,
                             height: 45 * SCREEN_RATIO,
                             filter: transfusionEffect ? "brightness(1.2)" : "none",
-                            animation: transfusionEffect ? "transfusion 1.5s linear" : "none",
+                            animation: clickPulse
+                                ? // The hourglass already spins 180deg on click, so it takes a flare only —
+                                  // scaling it as well fights the rotation. The AI control is a TOGGLE, so it
+                                  // gets the springier snap; everything else gets the plain press.
+                                  isHourglass
+                                    ? "hocIconFlip 0.42s ease-out"
+                                    : isToggle
+                                      ? "hocToggleSnap 0.42s cubic-bezier(0.34, 1.56, 0.64, 1)"
+                                      : "hocIconPress 0.28s ease-out"
+                                : transfusionEffect
+                                  ? "transfusion 1.5s linear"
+                                  : "none",
                             boxShadow: transfusionEffect
                                 ? `0 0 ${14 * SCREEN_RATIO}px rgba(255, 255, 255, 0.7)`
                                 : "none",
@@ -236,6 +291,19 @@ const ButtonComponent: React.FC<ButtonComponentProps> = ({
     );
 };
 
+// The FIGHT SQUARE's rect. The board is a 2048 square scaled to fit and centred, so this is what the dock
+// arrows should snap to -- sticking the bar to the WINDOW edge parks it out over the sidebars, and on a
+// wide screen leaves it stranded far from the board it acts on.
+const getBoardRect = (width: number, height: number) => {
+    const board = 2048 * Math.min(width / 2048, height / 2048);
+    return {
+        left: (width - board) / 2,
+        top: (height - board) / 2,
+        right: (width + board) / 2,
+        bottom: (height + board) / 2,
+    };
+};
+
 const getBarSize = (width: number, height: number) => {
     const widthRatio = width / 2048;
     const heightRatio = height / 2048;
@@ -282,8 +350,20 @@ const DraggableToolbar: React.FC = () => {
         // the old formula placed the toolbar's LEFT edge flush with the sidebar's left edge, so the whole
         // bar rendered on top of the sidebar instead of beside it.
         // Update: Landscape should stick to inside edge of sidebar (move left by button width)
+        // DEFAULT: docked into the RIGHT sidebar, sitting over it rather than beside it — the placement
+        // the bar has always had, and the one players reach for. Centred across the sidebar's width so it
+        // reads as part of that panel instead of a strip floating on its edge. The four dock arrows move
+        // it from here; nothing about this is sticky, so a reset always comes back to the right bar.
+        // Start docked INSIDE the fight square's right edge. The old formula used getBarSize(), the gutter
+        // between board and screen, which is 0 whenever the board fills the width -- so it collapsed to
+        // `width - toolbarWidth`, i.e. hard against the window's right edge, on top of the right sidebar.
+        // That is why the bar kept looking like part of that panel. The board rect has no such degenerate
+        // case, and the dock arrows move it from here.
         const toolbarWidth = toolbarRef.current?.offsetWidth ?? estimateToolbarWidth();
-        const x = isLandscape ? barSize - 48 * SCREEN_RATIO : Math.max(0, width - barSize - toolbarWidth);
+        void isLandscape;
+        void barSize;
+        const board = getBoardRect(width, height);
+        const x = Math.min(Math.max(0, board.right - toolbarWidth), Math.max(0, width - toolbarWidth));
 
         return {
             x,
@@ -296,6 +376,48 @@ const DraggableToolbar: React.FC = () => {
         const ds = getDefaultSettings();
         return { x: ds.x, y: ds.y };
     });
+
+    // Snap the bar to an edge of the battle screen instead of leaving it wherever it was dragged.
+    //
+    // Left and right dock VERTICALLY, top and bottom HORIZONTALLY, because the bar is a single strip and
+    // the long axis has to run along the edge it is stuck to. Right reproduces the default placement --
+    // overlapping the right sidebar rather than sitting beside it -- since that is where the bar already
+    // lives and what players are used to reaching for.
+    type DockSide = "left" | "right" | "top" | "bottom";
+    const dockTo = useCallback((side: DockSide) => {
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        const toolbarW = toolbarRef.current?.offsetWidth ?? estimateToolbarWidth();
+        const toolbarH = toolbarRef.current?.offsetHeight ?? estimateToolbarWidth();
+        const vertical = side === "left" || side === "right";
+
+        setIsVertical(vertical);
+        // Measured AFTER the orientation flip so the long/short axes are the right way round; without the
+        // frame delay the bar snaps using its pre-rotation size and hangs off the edge.
+        requestAnimationFrame(() => {
+            const w = toolbarRef.current?.offsetWidth ?? toolbarW;
+            const h = toolbarRef.current?.offsetHeight ?? toolbarH;
+            const board = getBoardRect(width, height);
+            const midY = board.top + (board.bottom - board.top) / 2 - h / 2;
+            const midX = board.left + (board.right - board.left) / 2 - w / 2;
+            const raw =
+                side === "left"
+                    ? { x: board.left, y: midY }
+                    : side === "right"
+                      ? { x: board.right - w, y: midY }
+                      : side === "top"
+                        ? { x: midX, y: board.top }
+                        : { x: midX, y: board.bottom - h };
+            // Clamped to the viewport last, so a board taller than the window can never push the bar off
+            // the bottom -- it was rendering partly outside the window.
+            const next = {
+                x: Math.min(Math.max(0, raw.x), Math.max(0, width - w)),
+                y: Math.min(Math.max(0, raw.y), Math.max(0, height - h)),
+            };
+            positionRef.current = next;
+            setPosition(next);
+        });
+    }, []);
 
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const [isVertical, setIsVertical] = useState<boolean>(() => getDefaultSettings().isVertical);
@@ -536,6 +658,60 @@ const DraggableToolbar: React.FC = () => {
             {buttonsContent}
 
             <Divider orientation={isVertical ? "horizontal" : "vertical"} />
+
+            {/* Dock arrows. Left/right stand the bar up along a side; top/bottom lay it across. */}
+            <Box
+                sx={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(3, 1fr)",
+                    gridTemplateAreas: `". up ." "left . right" ". down ."`,
+                    justifyItems: "center",
+                    alignItems: "center",
+                    gap: "1px",
+                    opacity: 0.75,
+                    "&:hover": { opacity: 1 },
+                }}
+            >
+                {(
+                    [
+                        ["up", "top", <KeyboardArrowUpIcon key="u" fontSize="small" />, "Dock to top"],
+                        ["left", "left", <ArrowBackIosNewIcon key="l" fontSize="small" />, "Dock to left"],
+                        ["right", "right", <ArrowForwardIosIcon key="r" fontSize="small" />, "Dock to right"],
+                        ["down", "bottom", <KeyboardArrowDownIcon key="d" fontSize="small" />, "Dock to bottom"],
+                    ] as const
+                ).map(([area, side, icon, label]) => (
+                    <Tooltip key={area} title={label} variant="soft">
+                        <Box
+                            component="button"
+                            aria-label={label}
+                            onClick={() => dockTo(side)}
+                            sx={{
+                                gridArea: area,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                width: 16 * SCREEN_RATIO,
+                                height: 16 * SCREEN_RATIO,
+                                padding: 0,
+                                border: "none",
+                                background: "transparent",
+                                cursor: "pointer",
+                                borderRadius: "4px",
+                                color: isDark ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.55)",
+                                transition: "transform 120ms ease-out, color 120ms ease-out",
+                                "& svg": { fontSize: `${12 * SCREEN_RATIO}px` },
+                                "&:hover": {
+                                    color: isDark ? "#fff" : "#000",
+                                    transform: "scale(1.25)",
+                                },
+                                "&:active": { transform: "scale(0.9)" },
+                            }}
+                        >
+                            {icon}
+                        </Box>
+                    </Tooltip>
+                ))}
+            </Box>
 
             <Tooltip title="Rotate Toolbar" variant="soft">
                 <StyledIconButton

--- a/game/core/src/ui/LeftSideBar/MessageBox.tsx
+++ b/game/core/src/ui/LeftSideBar/MessageBox.tsx
@@ -22,6 +22,7 @@ import { meteorIconDataUrl } from "../meteorIcon";
 import { TurnTimerBar } from "./TurnTimerBar";
 import { useSidebarMetrics } from "./sidebarMetrics";
 
+import { commonTooltipSx } from "./tooltipStyles";
 // --- Configuration for the Start Button Atlas ---
 const START_BUTTON_META = {
     frameWidth: 344,
@@ -33,17 +34,6 @@ const START_BUTTON_META = {
 };
 
 // --- Custom Style for "Heroes" Aesthetic Tooltips ---
-const commonTooltipSx = {
-    backgroundColor: "#2d1606", // Deep dark brown/wood
-    border: "2px solid #dcb158", // Metallic gold/bronze border
-    color: "#efe4cc", // Parchment/Cream text for contrast
-    borderRadius: "8px",
-    boxShadow: "0 6px 12px rgba(0,0,0,0.8)",
-    fontSize: "0.85rem",
-    fontWeight: 500,
-    maxWidth: "280px",
-    zIndex: 10000,
-};
 
 // 1. Animated Button Component (Ping-Pong Loop)
 const AnimatedStartButton = ({ onClick, scale }: { onClick: () => void; scale: number }) => {

--- a/game/core/src/ui/LeftSideBar/SynergiesRow.tsx
+++ b/game/core/src/ui/LeftSideBar/SynergiesRow.tsx
@@ -6,7 +6,18 @@ import React, { useMemo } from "react";
 
 import { useSidebarMetrics } from "./sidebarMetrics";
 
-const SynergiesRow = ({ synergies, wrap = false }: { synergies: string[]; wrap?: boolean }) => {
+import { commonTooltipSx } from "./tooltipStyles";
+const SynergiesRow = ({
+    synergies,
+    wrap = false,
+    column = false,
+}: {
+    synergies: string[];
+    wrap?: boolean;
+    // Stack the badges vertically. Used where the strip is pinned into a corner beside the portrait rather
+    // than laid across the bar, where a horizontal run would cover the art.
+    column?: boolean;
+}) => {
     const metrics = useSidebarMetrics();
     const sortedSynergies = useMemo(
         () =>
@@ -28,9 +39,10 @@ const SynergiesRow = ({ synergies, wrap = false }: { synergies: string[]; wrap?:
                 display: "flex",
                 // The strip wraps instead of overflowing: four synergy badges do not fit a 128px bar on
                 // one line, and the row is a fixed part of the sidebar's height budget.
+                flexDirection: column ? "column" : "row",
                 gap: `${metrics.gapPx * 0.6}px`,
                 rowGap: wrap ? 1.5 : `${metrics.gapPx * 0.5}px`,
-                flexWrap: "wrap",
+                flexWrap: column ? "nowrap" : "wrap",
                 justifyContent: wrap ? "center" : "flex-start",
                 // Shrink to content when inlined (the Buffs row puts these beside the buff tiles); only the
                 // standalone wrapped variant claims the full width.
@@ -64,6 +76,7 @@ const SynergiesRow = ({ synergies, wrap = false }: { synergies: string[]; wrap?:
                                 .replace(/\{\}/, SynergyKeysToPower[synergyKey]?.[0]?.toString() || "0")
                                 .replace(/\{\}/, SynergyKeysToPower[synergyKey]?.[1]?.toString() || "0")}`}
                             placement="bottom"
+                            sx={commonTooltipSx}
                         >
                             <Box
                                 component="img"

--- a/game/core/src/ui/LeftSideBar/TurnTimerBar.tsx
+++ b/game/core/src/ui/LeftSideBar/TurnTimerBar.tsx
@@ -35,12 +35,17 @@ export const TurnTimerBar: React.FC<TurnTimerBarProps> = ({
     const medallion = Math.round(Math.max(26, Math.min(40, metrics.contentWidth * 0.22)));
     const grooveHeight = Math.round(Math.max(12, medallion * 0.45));
 
-    // On the opponent's turn the fill goes red; otherwise it stays neutral so it does not
-    // read as green-team ownership.
-    const fillLight = enemyTurn ? "#ff8a73" : "#f4f6f8";
-    const fillBase = enemyTurn ? "#f4593f" : "#d5dbe3";
-    const fillDark = enemyTurn ? "#c2351f" : "#a8b1bf";
-    const fillGlow = enemyTurn ? "rgba(255, 90, 63, 0.5)" : "rgba(226, 232, 240, 0.45)";
+    // The fill carries the state rather than just filling space: warm amber while there is time, deepening
+    // to red under CRITICAL_SECONDS, and red throughout on the opponent's clock. The old fill was a
+    // grey-white gradient, which sat oddly inside a gold frame and — being the same colour whether you had
+    // fifty seconds or four — left the number doing all the work. Amber is deliberately not the team green,
+    // so a full bar never reads as "your team owns this".
+    const palette = enemyTurn
+        ? { light: "#ff8a73", base: "#f4593f", dark: "#c2351f", glow: "rgba(255,90,63,0.34)" }
+        : critical
+          ? { light: "#ffb36b", base: "#ef6c3a", dark: "#b83a17", glow: "rgba(239,108,58,0.38)" }
+          : { light: "#ffe6ab", base: "#e8b558", dark: "#a87526", glow: "rgba(232,181,88,0.28)" };
+    const { light: fillLight, base: fillBase, dark: fillDark, glow: fillGlow } = palette;
 
     return (
         <Box
@@ -134,7 +139,7 @@ export const TurnTimerBar: React.FC<TurnTimerBarProps> = ({
                         borderRadius: "7px",
                         transition: TICK_TRANSITION,
                         background: `linear-gradient(180deg, ${fillLight} 0%, ${fillBase} 52%, ${fillDark} 100%)`,
-                        boxShadow: `0 0 7px ${fillGlow}`,
+                        boxShadow: `0 0 5px ${fillGlow}`,
                         // Glossy top sheen so the fill looks like a polished gauge, not a flat block.
                         "&::after": {
                             content: '""',
@@ -142,7 +147,7 @@ export const TurnTimerBar: React.FC<TurnTimerBarProps> = ({
                             inset: 0,
                             borderRadius: "7px",
                             background:
-                                "linear-gradient(180deg, rgba(255,255,255,0.4) 0%, rgba(255,255,255,0.05) 42%, rgba(255,255,255,0) 60%)",
+                                "linear-gradient(180deg, rgba(255,255,255,0.26) 0%, rgba(255,255,255,0.04) 46%, rgba(255,255,255,0) 62%)",
                             pointerEvents: "none",
                         },
                     }}

--- a/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
+++ b/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
@@ -39,6 +39,7 @@ import { MagicShieldIcon } from "../svg/magic_shield";
 import { MoraleIcon } from "../svg/morale";
 import { QuiverIcon } from "../svg/quiver";
 import { ShieldIcon } from "../svg/shield";
+import { ScrollIcon } from "../svg/scroll";
 import { ShotRangeIcon } from "../svg/shot_range";
 import { SpeedIcon } from "../svg/speed";
 import { SwordIcon } from "../svg/sword";
@@ -585,6 +586,16 @@ const TEAM_AURA = {
         inner: "radial-gradient(circle, rgba(255,175,160,.3) 46%, rgba(250,70,45,.16) 68%, transparent 88%)",
         ringHalo: "rgba(255,90,63,.4)",
     },
+    // Unaffiliated creatures — the units overlay, where nothing has picked a side yet. A hueless light
+    // grey, and slightly dimmer than the team tones so a roster entry never competes with a real
+    // combatant for attention. Without this the tone was chosen by a two-way LOWER/else ternary, so every
+    // teamless creature burned red and read as an enemy.
+    neutral: {
+        outer: "radial-gradient(circle, rgba(228,228,228,.30) 34%, rgba(176,176,176,.16) 60%, transparent 82%)",
+        mid: "radial-gradient(circle, rgba(238,238,238,.26) 40%, rgba(190,190,190,.14) 64%, transparent 86%)",
+        inner: "radial-gradient(circle, rgba(248,248,248,.22) 46%, rgba(205,205,205,.12) 68%, transparent 88%)",
+        ringHalo: "rgba(216,216,216,.32)",
+    },
 } as const;
 
 // A slow, steady burn. Opacity barely moves (no blinking) — what changes is the silhouette: the corner
@@ -773,15 +784,30 @@ const EffectTiles: React.FC<{
  * One cell of the stat plate. Optionally carries a second stat beside the first — morale and luck share a
  * cell so a creature with extra (ranged) stats still fits the fixed three-row grid.
  */
-const StatValue: React.FC<{
-    icon: React.ReactElement<Record<string, unknown>>;
-    value: string | number;
-    color: string;
-    metrics: ISidebarMetrics;
-}> = ({ icon, value, color, metrics }) => (
+/**
+ * One icon + number.
+ *
+ * forwardRef, and it spreads whatever else it is given onto the Box, because every one of these is wrapped
+ * in a <Tooltip>. MUI hands its child the hover/focus handlers and a ref by cloning it; a plain function
+ * component silently drops both, and the stat explanations stop appearing on hover with nothing in the
+ * console to say why. If this stops forwarding, the tooltips go quiet again.
+ */
+const StatValue = React.forwardRef<
+    HTMLDivElement,
+    {
+        icon: React.ReactElement<Record<string, unknown>>;
+        value: string | number;
+        color: string;
+        metrics: ISidebarMetrics;
+    } & React.HTMLAttributes<HTMLDivElement>
+>(({ icon, value, color, metrics, ...tooltipProps }, ref) => (
     // No buff/debuff frame: a modified stat used to get a pulsing green or red ring, which on creatures
     // that carry a permanent modifier sat on screen for the whole fight and read as clutter.
-    <Box sx={{ display: "inline-flex", alignItems: "center", width: "fit-content", minWidth: 0 }}>
+    <Box
+        ref={ref}
+        {...tooltipProps}
+        sx={{ display: "inline-flex", alignItems: "center", width: "fit-content", minWidth: 0 }}
+    >
         {React.cloneElement(icon, {
             sx: { color, fontSize: `${metrics.statIconPx}px`, pr: "3px", flex: "none" },
         })}
@@ -789,7 +815,8 @@ const StatValue: React.FC<{
             {value}
         </Typography>
     </Box>
-);
+));
+StatValue.displayName = "StatValue";
 
 const StatItem: React.FC<{
     icon: React.ReactElement<Record<string, unknown>>;
@@ -909,9 +936,17 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={<ShieldIcon />}
                 value={Math.round(meleeArmor)}
-                tooltip="Armor"
+                tooltip={hasDifferentRangeArmor ? "Armor against melee attacks" : "Armor"}
                 color="#4682b4"
                 metrics={metrics}
+                // A creature that armours differently against arrows shows both figures in ONE cell, the
+                // way morale and luck share theirs. They are the same stat read against two attack types,
+                // so splitting them across the grid made the pair read as unrelated -- and the second cell
+                // only existed for some creatures, which shifted every stat after it.
+                secondIcon={hasDifferentRangeArmor ? <ArrowShieldIcon /> : undefined}
+                secondValue={hasDifferentRangeArmor ? Math.round(rangeArmor) : undefined}
+                secondColor="#f4a460"
+                secondTooltip="Armor against ranged attacks"
             />
             <StatItem
                 icon={<MagicShieldIcon />}
@@ -939,20 +974,23 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={<MoraleIcon />}
                 value={Math.round(unitProperties.morale)}
-                tooltip="Morale affects extra actions"
+                tooltip="Morale grants extra actions, and adds movement steps once the map starts narrowing"
                 color={isDarkMode ? "#ffff00" : "#DC4D01"}
                 metrics={metrics}
                 secondIcon={<LuckIcon />}
                 secondValue={Math.round(unitProperties.luck + unitProperties.luck_mod)}
                 secondColor="#ff4040"
-                secondTooltip="Luck affects damage variance"
+                secondTooltip="Luck raises damage rolls and the power of abilities"
             />
-            {hasDifferentRangeArmor && (
+            {/* Spellbook scroll count. Dropped in the sidebar rebuild -- it is the only readout of how many
+                casts a spellcaster has left, so losing it meant checking the spellbook to answer a question
+                the stat block used to answer at a glance. */}
+            {unitProperties.can_cast_spells && (
                 <StatItem
-                    icon={<ArrowShieldIcon />}
-                    value={Math.round(rangeArmor)}
-                    tooltip="Range armor"
-                    color="#f4a460"
+                    icon={<ScrollIcon />}
+                    value={unitProperties.spells.length}
+                    tooltip="Magic scrolls left to cast"
+                    color="#add8e6"
                     metrics={metrics}
                 />
             )}
@@ -977,7 +1015,8 @@ const UnitStatsLayout: React.FC<{
         </>
     );
     const unitSynergies = ((unitProperties as UnitProperties).synergies as string[]) ?? [];
-    const auraTone = team === TeamVals.LOWER ? TEAM_AURA.green : TEAM_AURA.red;
+    const auraTone =
+        team === TeamVals.LOWER ? TEAM_AURA.green : team === TeamVals.UPPER ? TEAM_AURA.red : TEAM_AURA.neutral;
     // Three stat rows, always — the well below scrolls if a creature carries more than nine.
     const statRowHeight = Math.round(metrics.statIconPx + 12);
     const statWellHeight = statRowHeight * 3 + STAT_ROW_GAP * 2;
@@ -1152,25 +1191,20 @@ const UnitStatsLayout: React.FC<{
                 </ScrollWell>
             </PanelSection>
 
-            {/* Synergies ride along with the buffs instead of a separate top-left HUD: they come off the
-                selected unit's own properties, so a green stack shows green's synergies and a red one
-                shows red's, with no extra plumbing. */}
+            {/* Synergies get their own section rather than sharing the Buffs well. They are not buffs: a buff
+                is something applied to THIS stack that will expire, while a synergy is a standing property of
+                the army's faction make-up. Mixed into one row they read as castable effects someone could
+                dispel, and the Buffs count stopped matching what was actually on the unit. Still driven by the
+                selected unit's own properties, so a green stack shows green's synergies and a red one red's. */}
+            {unitSynergies.length > 0 && (
+                <PanelSection title="Synergies" metrics={metrics}>
+                    <SynergiesRow synergies={unitSynergies} />
+                </PanelSection>
+            )}
+
             <PanelSection title="Buffs" metrics={metrics}>
                 <ScrollWell height={effectWellHeight}>
-                    {/* Buff tiles and synergy badges share one wrapping row rather than stacking as two
-                        blocks — they are all "what is currently boosting this stack". */}
-                    <Box
-                        sx={{
-                            display: "flex",
-                            flexDirection: "row",
-                            flexWrap: "wrap",
-                            alignItems: "flex-start",
-                            gap: `${metrics.gapPx * 0.6}px`,
-                        }}
-                    >
-                        {buffs.length > 0 && <EffectTiles effects={buffs} title="Buffs" metrics={metrics} />}
-                        {unitSynergies.length > 0 && <SynergiesRow synergies={unitSynergies} />}
-                    </Box>
+                    {buffs.length > 0 && <EffectTiles effects={buffs} title="Buffs" metrics={metrics} />}
                 </ScrollWell>
             </PanelSection>
 

--- a/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
+++ b/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
@@ -744,8 +744,14 @@ const EffectTiles: React.FC<{
 const MOD_UP_COLOR = "#7ee787";
 const MOD_DOWN_COLOR = "#ff8a7a";
 
-/** undefined when a stat sits at its base value, so unmodified stats stay plain parchment. */
-const modOf = (delta: number): "up" | "down" | undefined => (delta > 0 ? "up" : delta < 0 ? "down" : undefined);
+/**
+ * The signed delta a buff/debuff applied, as the text shown beside the stat -- "+2", "-1".
+ *
+ * The AMOUNT is the point: the number displayed is already the modified one, so a tint alone tells you
+ * something changed but not what it cost. Empty when the stat is at its base, so unmodified stats stay
+ * plain parchment.
+ */
+const modLabel = (delta: number): string => (delta ? `${delta > 0 ? "+" : ""}${Number(delta.toFixed(2))}` : "");
 
 const StatValue = React.forwardRef<
     HTMLDivElement,
@@ -754,8 +760,8 @@ const StatValue = React.forwardRef<
         value: string | number;
         color: string;
         metrics: ISidebarMetrics;
-        /** Set when a buff or debuff has moved this stat off its base value. */
-        modifier?: "up" | "down";
+        /** Signed delta text ("+2", "-1"); empty when the stat is at its base value. */
+        modifier?: string;
     } & React.HTMLAttributes<HTMLDivElement>
 >(({ icon, value, color, metrics, modifier, ...tooltipProps }, ref) => (
     // No buff/debuff frame: a modified stat used to get a pulsing green or red ring, which on creatures
@@ -778,14 +784,20 @@ const StatValue = React.forwardRef<
                 // with a permanent modifier it sat on screen all fight and read as clutter. The
                 // information still matters, so it moves onto the number itself: no animation, no extra
                 // chrome, and the caret keeps it readable without relying on colour alone.
-                color: modifier === "up" ? MOD_UP_COLOR : modifier === "down" ? MOD_DOWN_COLOR : undefined,
-                fontWeight: modifier ? 700 : undefined,
             }}
         >
             {value}
             {modifier && (
-                <Box component="span" sx={{ fontSize: "0.72em", ml: "1px", verticalAlign: "0.08em" }}>
-                    {modifier === "up" ? "\u25B2" : "\u25BC"}
+                <Box
+                    component="span"
+                    sx={{
+                        fontSize: "0.78em",
+                        ml: "2px",
+                        fontWeight: 700,
+                        color: modifier.startsWith("-") ? MOD_DOWN_COLOR : MOD_UP_COLOR,
+                    }}
+                >
+                    {modifier}
                 </Box>
             )}
         </Typography>
@@ -803,8 +815,8 @@ const StatItem: React.FC<{
     secondValue?: string | number;
     secondColor?: string;
     secondTooltip?: string;
-    modifier?: "up" | "down";
-    secondModifier?: "up" | "down";
+    modifier?: string;
+    secondModifier?: string;
 }> = ({
     icon,
     value,
@@ -924,7 +936,11 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={attackTypeSelected === AttackVals.RANGE ? <BowIcon /> : <SwordIcon />}
                 value={Math.round(attackDamage)}
-                modifier={modOf(unitProperties.attack_multiplier - 1)}
+                modifier={
+                    unitProperties.attack_multiplier !== 1
+                        ? `x${Number(unitProperties.attack_multiplier.toFixed(2))}`
+                        : ""
+                }
                 tooltip="Attack type and multiplier"
                 color={attackTypeSelected === AttackVals.RANGE ? "#ffd700" : "#a52a2a"}
                 metrics={metrics}
@@ -935,8 +951,8 @@ const UnitStatsLayout: React.FC<{
                 tooltip={hasDifferentRangeArmor ? "Armor against melee attacks" : "Armor"}
                 color="#4682b4"
                 metrics={metrics}
-                modifier={modOf(unitProperties.armor_mod)}
-                secondModifier={modOf(unitProperties.armor_mod)}
+                modifier={modLabel(unitProperties.armor_mod)}
+                secondModifier={modLabel(unitProperties.armor_mod)}
                 // A creature that armours differently against arrows shows both figures in ONE cell, the
                 // way morale and luck share theirs. They are the same stat read against two attack types,
                 // so splitting them across the grid made the pair read as unrelated -- and the second cell
@@ -958,7 +974,7 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={unitProperties.movement_type === MovementVals.FLY ? <WingIcon /> : <BootIcon />}
                 value={Math.floor(unitProperties.steps + stepsMod)}
-                modifier={modOf(stepsMod)}
+                modifier={modLabel(stepsMod)}
                 tooltip="Movement type and number of steps in cells"
                 color={unitProperties.movement_type === MovementVals.FLY ? "#00ff7f" : "#8b4513"}
                 metrics={metrics}
@@ -973,7 +989,7 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={<MoraleIcon />}
                 value={Math.round(unitProperties.morale)}
-                secondModifier={modOf(unitProperties.luck_mod)}
+                secondModifier={modLabel(unitProperties.luck_mod)}
                 tooltip="Morale grants extra actions, and adds movement steps once the map starts narrowing"
                 color={isDarkMode ? "#ffff00" : "#DC4D01"}
                 metrics={metrics}

--- a/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
+++ b/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
@@ -1,4 +1,5 @@
 import {
+    HoCConfig,
     HoCConstants,
     UnitProperties,
     AttackVals,
@@ -907,6 +908,22 @@ const UnitStatsLayout: React.FC<{
     hasBreakApplied,
     team,
 }) => {
+    // Luck's display delta has to be DERIVED, not read from luck_mod.
+    //
+    // In the sandbox luck_mod carries the buff and the delta is just that. In ranked it is hardcoded to 0:
+    // the server ships luck already rolled (auras + the per-turn spread) with luck_authoritative set, so
+    // adjustBaseStats keeps it verbatim. Writing the delta into luck_mod to make the HUD work would be a
+    // gameplay bug, because getLuck() sums luck + luck_mod -- it would inflate real damage rolls and
+    // ability chances, not just this label. So the effective total is diffed against the creature's
+    // configured base instead, which is display-only and correct on both paths.
+    const configuredLuck = HoCConfig.getCreatureConfig(
+        unitProperties.team,
+        ToFactionName[unitProperties.faction],
+        unitProperties.name,
+        unitProperties.large_texture_name,
+        0,
+    ).luck;
+    const luckDelta = Math.round(unitProperties.luck + unitProperties.luck_mod) - Math.round(configuredLuck);
     const animationConfig = getDefaultAnimationConfig(unitProperties.name);
     const showRangedStats =
         unitProperties.attack_type === AttackVals.RANGE ||
@@ -989,7 +1006,7 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={<MoraleIcon />}
                 value={Math.round(unitProperties.morale)}
-                secondModifier={modLabel(unitProperties.luck_mod)}
+                secondModifier={modLabel(luckDelta)}
                 tooltip="Morale grants extra actions, and adds movement steps once the map starts narrowing"
                 color={isDarkMode ? "#ffff00" : "#DC4D01"}
                 metrics={metrics}
@@ -1433,6 +1450,7 @@ const UnitStatsListItemInner: React.FC<UnitStatsListItemProps> = ({ unitProperti
         const meleeArmor = Math.max(1, unitProperties.base_armor + unitProperties.armor_mod);
         const rangeArmor = Math.max(1, unitProperties.range_armor + unitProperties.armor_mod);
         const hasDifferentRangeArmor = meleeArmor !== rangeArmor;
+
         const largeTextureName = unitProperties.large_texture_name;
 
         return (

--- a/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
+++ b/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
@@ -19,7 +19,6 @@ import ListItem from "@mui/joy/ListItem";
 import ListItemButton from "@mui/joy/ListItemButton";
 import ListItemContent from "@mui/joy/ListItemContent";
 import Stack from "@mui/joy/Stack";
-import { useTheme } from "@mui/joy/styles";
 import Tooltip from "@mui/joy/Tooltip";
 import Typography from "@mui/joy/Typography";
 import React, { useCallback } from "react";
@@ -360,8 +359,8 @@ const AbilityCell: React.FC<{
     size: number;
     hasBreakApplied: boolean;
 }> = ({ ability, teamType, size, hasBreakApplied }) => {
-    const theme = useTheme();
-    const isDarkMode = theme.palette.mode === "dark";
+    // The game renders dark-only; the light palette is gone, so this is a constant.
+    const isDarkMode = true;
     const auraColor = isDarkMode ? "rgba(255, 255, 255, 0.75)" : "rgba(0, 0, 0, 0.75)";
     const disabledStatus = ability.isStolen
         ? { label: "STOLEN", color: "#9acd32", tooltip: "ABILITY STOLEN PERMANENTLY!\n" }
@@ -1189,9 +1188,9 @@ type UnitStatsListItemProps = {
 };
 
 const UnitStatsListItemInner: React.FC<UnitStatsListItemProps> = ({ unitProperties, overallImpact, factionType }) => {
-    const theme = useTheme();
     const metrics = useSidebarMetrics();
-    const isDarkMode = theme.palette.mode === "dark";
+    // The game renders dark-only; the light palette is gone, so this is a constant.
+    const isDarkMode = true;
     const abilities: IVisibleImpact[] = overallImpact.abilities || [];
     const buffs: IVisibleImpact[] = overallImpact.buffs || [];
     const debuffs: IVisibleImpact[] = overallImpact.debuffs || [];

--- a/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
+++ b/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
@@ -739,6 +739,14 @@ const EffectTiles: React.FC<{
  * component silently drops both, and the stat explanations stop appearing on hover with nothing in the
  * console to say why. If this stops forwarding, the tooltips go quiet again.
  */
+// Gold-friendly green/red for a modified stat: bright enough to read against the dark plate without
+// fighting the parchment numbers around them.
+const MOD_UP_COLOR = "#7ee787";
+const MOD_DOWN_COLOR = "#ff8a7a";
+
+/** undefined when a stat sits at its base value, so unmodified stats stay plain parchment. */
+const modOf = (delta: number): "up" | "down" | undefined => (delta > 0 ? "up" : delta < 0 ? "down" : undefined);
+
 const StatValue = React.forwardRef<
     HTMLDivElement,
     {
@@ -746,8 +754,10 @@ const StatValue = React.forwardRef<
         value: string | number;
         color: string;
         metrics: ISidebarMetrics;
+        /** Set when a buff or debuff has moved this stat off its base value. */
+        modifier?: "up" | "down";
     } & React.HTMLAttributes<HTMLDivElement>
->(({ icon, value, color, metrics, ...tooltipProps }, ref) => (
+>(({ icon, value, color, metrics, modifier, ...tooltipProps }, ref) => (
     // No buff/debuff frame: a modified stat used to get a pulsing green or red ring, which on creatures
     // that carry a permanent modifier sat on screen for the whole fight and read as clutter.
     <Box
@@ -758,8 +768,26 @@ const StatValue = React.forwardRef<
         {React.cloneElement(icon, {
             sx: { color, fontSize: `${metrics.statIconPx}px`, pr: "3px", flex: "none" },
         })}
-        <Typography fontSize={`${metrics.statFontRem}rem`} component="span" sx={{ whiteSpace: "nowrap" }}>
+        <Typography
+            fontSize={`${metrics.statFontRem}rem`}
+            component="span"
+            sx={{
+                whiteSpace: "nowrap",
+                // A buffed or debuffed stat is TINTED, and carries a small caret. The rebuild dropped the
+                // old treatment -- a pulsing green/red ring around the whole cell -- because on a creature
+                // with a permanent modifier it sat on screen all fight and read as clutter. The
+                // information still matters, so it moves onto the number itself: no animation, no extra
+                // chrome, and the caret keeps it readable without relying on colour alone.
+                color: modifier === "up" ? MOD_UP_COLOR : modifier === "down" ? MOD_DOWN_COLOR : undefined,
+                fontWeight: modifier ? 700 : undefined,
+            }}
+        >
             {value}
+            {modifier && (
+                <Box component="span" sx={{ fontSize: "0.72em", ml: "1px", verticalAlign: "0.08em" }}>
+                    {modifier === "up" ? "\u25B2" : "\u25BC"}
+                </Box>
+            )}
         </Typography>
     </Box>
 ));
@@ -775,8 +803,22 @@ const StatItem: React.FC<{
     secondValue?: string | number;
     secondColor?: string;
     secondTooltip?: string;
-}> = ({ icon, value, tooltip, color, metrics, secondIcon, secondValue, secondColor, secondTooltip }) => {
-    const first = <StatValue icon={icon} value={value} color={color} metrics={metrics} />;
+    modifier?: "up" | "down";
+    secondModifier?: "up" | "down";
+}> = ({
+    icon,
+    value,
+    tooltip,
+    color,
+    metrics,
+    secondIcon,
+    secondValue,
+    secondColor,
+    secondTooltip,
+    modifier,
+    secondModifier,
+}) => {
+    const first = <StatValue icon={icon} value={value} color={color} metrics={metrics} modifier={modifier} />;
 
     return (
         <Box
@@ -801,7 +843,13 @@ const StatItem: React.FC<{
             </Tooltip>
             {secondIcon && secondValue !== undefined && (
                 <Tooltip title={secondTooltip ?? ""} sx={commonTooltipSx}>
-                    <StatValue icon={secondIcon} value={secondValue} color={secondColor ?? color} metrics={metrics} />
+                    <StatValue
+                        icon={secondIcon}
+                        value={secondValue}
+                        color={secondColor ?? color}
+                        metrics={metrics}
+                        modifier={secondModifier}
+                    />
                 </Tooltip>
             )}
         </Box>
@@ -876,6 +924,7 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={attackTypeSelected === AttackVals.RANGE ? <BowIcon /> : <SwordIcon />}
                 value={Math.round(attackDamage)}
+                modifier={modOf(unitProperties.attack_multiplier - 1)}
                 tooltip="Attack type and multiplier"
                 color={attackTypeSelected === AttackVals.RANGE ? "#ffd700" : "#a52a2a"}
                 metrics={metrics}
@@ -886,6 +935,8 @@ const UnitStatsLayout: React.FC<{
                 tooltip={hasDifferentRangeArmor ? "Armor against melee attacks" : "Armor"}
                 color="#4682b4"
                 metrics={metrics}
+                modifier={modOf(unitProperties.armor_mod)}
+                secondModifier={modOf(unitProperties.armor_mod)}
                 // A creature that armours differently against arrows shows both figures in ONE cell, the
                 // way morale and luck share theirs. They are the same stat read against two attack types,
                 // so splitting them across the grid made the pair read as unrelated -- and the second cell
@@ -907,6 +958,7 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={unitProperties.movement_type === MovementVals.FLY ? <WingIcon /> : <BootIcon />}
                 value={Math.floor(unitProperties.steps + stepsMod)}
+                modifier={modOf(stepsMod)}
                 tooltip="Movement type and number of steps in cells"
                 color={unitProperties.movement_type === MovementVals.FLY ? "#00ff7f" : "#8b4513"}
                 metrics={metrics}
@@ -921,6 +973,7 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={<MoraleIcon />}
                 value={Math.round(unitProperties.morale)}
+                secondModifier={modOf(unitProperties.luck_mod)}
                 tooltip="Morale grants extra actions, and adds movement steps once the map starts narrowing"
                 color={isDarkMode ? "#ffff00" : "#DC4D01"}
                 metrics={metrics}

--- a/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
+++ b/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
@@ -908,6 +908,24 @@ const UnitStatsLayout: React.FC<{
     hasBreakApplied,
     team,
 }) => {
+    // magic_resist_mod and range_shots_mod REPLACE their base rather than adding to it (Enchanted Skin
+    // sets the resist outright), so the delta has to be computed against the base instead of printed
+    // straight -- "+40" would be wrong for a mod that means "40 total".
+    const magicResistDelta = unitProperties.magic_resist_mod
+        ? Math.round(unitProperties.magic_resist_mod) - Math.round(unitProperties.magic_resist)
+        : 0;
+    const rangeShotsDelta = unitProperties.range_shots_mod
+        ? Math.round(unitProperties.range_shots_mod) - Math.round(unitProperties.range_shots)
+        : 0;
+
+    // Additive first, then the multiplier — the same order and shape mainline used.
+    const attackModifierLabel = [
+        modLabel(unitProperties.attack_mod),
+        unitProperties.attack_multiplier !== 1 ? `x${Number(unitProperties.attack_multiplier.toFixed(2))}` : "",
+    ]
+        .filter(Boolean)
+        .join(" ");
+
     // Luck's display delta has to be DERIVED, not read from luck_mod.
     //
     // In the sandbox luck_mod carries the buff and the delta is just that. In ranked it is hardcoded to 0:
@@ -953,11 +971,11 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={attackTypeSelected === AttackVals.RANGE ? <BowIcon /> : <SwordIcon />}
                 value={Math.round(attackDamage)}
-                modifier={
-                    unitProperties.attack_multiplier !== 1
-                        ? `x${Number(unitProperties.attack_multiplier.toFixed(2))}`
-                        : ""
-                }
+                // Attack carries TWO kinds of modifier and both have to show. Mass Riot (and Weakness,
+                // Fireforged Sword, Warlord's Edge...) move attack_mod, which is ADDITIVE and already folded
+                // into the number above -- so without printing it the buff simply disappeared into the stat.
+                // attack_multiplier is separate and multiplicative. Mainline printed both, e.g. "+5 x1.5".
+                modifier={attackModifierLabel}
                 tooltip="Attack type and multiplier"
                 color={attackTypeSelected === AttackVals.RANGE ? "#ffd700" : "#a52a2a"}
                 metrics={metrics}
@@ -982,6 +1000,7 @@ const UnitStatsLayout: React.FC<{
             <StatItem
                 icon={<MagicShieldIcon />}
                 value={`${Math.round(unitProperties.magic_resist_mod || unitProperties.magic_resist)}%`}
+                modifier={modLabel(magicResistDelta)}
                 tooltip="Magic resist in %"
                 color="#8a2be2"
                 metrics={metrics}
@@ -1040,6 +1059,7 @@ const UnitStatsLayout: React.FC<{
                 <StatItem
                     icon={<QuiverIcon />}
                     value={unitProperties.range_shots_mod || unitProperties.range_shots}
+                    modifier={modLabel(rangeShotsDelta)}
                     tooltip="Number of ranged shots"
                     color="#cd5c5c"
                     metrics={metrics}

--- a/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
+++ b/game/core/src/ui/LeftSideBar/UnitStatsListItem.tsx
@@ -48,22 +48,11 @@ import Toggler from "../Toggler";
 import { SYNERGY_KEY_TO_IMAGE, SYNERGY_NAME_TO_DESCRIPTION } from "./SynergiesConstants";
 import { useSidebarMetrics, type ISidebarMetrics } from "./sidebarMetrics";
 
+import { commonTooltipSx } from "./tooltipStyles";
 interface IAbilityStackProps {
     abilities: IVisibleImpact[];
     teamType: TeamType;
 }
-
-const commonTooltipSx = {
-    backgroundColor: "#2d1606",
-    border: "2px solid #dcb158",
-    color: "#efe4cc",
-    borderRadius: "8px",
-    boxShadow: "0 6px 12px rgba(0,0,0,0.8)",
-    fontSize: "0.85rem",
-    fontWeight: 500,
-    maxWidth: "280px",
-    zIndex: 10000,
-};
 
 const FACTION_SYNERGY_IDS = [1, 2] as const;
 const FACTION_SYNERGY_LEVELS = [1, 2, 3] as const;
@@ -573,30 +562,6 @@ export const stonePlateSx = {
 
 // Team colour lives only as a diffuse, fire-like aura behind the portrait — three blurred discs that
 // breathe and flicker. No cloth banner, and nothing clips the ring.
-const TEAM_AURA = {
-    green: {
-        outer: "radial-gradient(circle, rgba(30,255,105,.42) 34%, rgba(0,215,70,.22) 60%, transparent 82%)",
-        mid: "radial-gradient(circle, rgba(90,255,150,.36) 40%, rgba(10,230,85,.19) 64%, transparent 86%)",
-        inner: "radial-gradient(circle, rgba(160,255,195,.3) 46%, rgba(35,245,105,.16) 68%, transparent 88%)",
-        ringHalo: "rgba(46,240,104,.4)",
-    },
-    red: {
-        outer: "radial-gradient(circle, rgba(255,70,45,.42) 34%, rgba(225,25,15,.22) 60%, transparent 82%)",
-        mid: "radial-gradient(circle, rgba(255,120,95,.36) 40%, rgba(240,45,28,.19) 64%, transparent 86%)",
-        inner: "radial-gradient(circle, rgba(255,175,160,.3) 46%, rgba(250,70,45,.16) 68%, transparent 88%)",
-        ringHalo: "rgba(255,90,63,.4)",
-    },
-    // Unaffiliated creatures — the units overlay, where nothing has picked a side yet. A hueless light
-    // grey, and slightly dimmer than the team tones so a roster entry never competes with a real
-    // combatant for attention. Without this the tone was chosen by a two-way LOWER/else ternary, so every
-    // teamless creature burned red and read as an enemy.
-    neutral: {
-        outer: "radial-gradient(circle, rgba(228,228,228,.30) 34%, rgba(176,176,176,.16) 60%, transparent 82%)",
-        mid: "radial-gradient(circle, rgba(238,238,238,.26) 40%, rgba(190,190,190,.14) 64%, transparent 86%)",
-        inner: "radial-gradient(circle, rgba(248,248,248,.22) 46%, rgba(205,205,205,.12) 68%, transparent 88%)",
-        ringHalo: "rgba(216,216,216,.32)",
-    },
-} as const;
 
 // A slow, steady burn. Opacity barely moves (no blinking) — what changes is the silhouette: the corner
 // radii creep from one irregular shape to the next over ~20s, so the edge is always drifting and never
@@ -636,23 +601,6 @@ const teamAuraKeyframes = {
     },
 } as const;
 
-const auraFlameSx = (width: number, background: string, blur: number, animation: string, opacity: number) =>
-    ({
-        position: "absolute",
-        top: "50%",
-        left: "50%",
-        width: `${width}px`,
-        height: `${Math.round(width * 1.04)}px`,
-        transform: "translate(-50%, -50%)",
-        background,
-        filter: `blur(${blur}px)`,
-        opacity,
-        pointerEvents: "none",
-        zIndex: 0,
-        animation,
-        "@media (prefers-reduced-motion: reduce)": { animation: "none" },
-    }) as const;
-
 const STAT_ROW_GAP = 8;
 
 // Slim bronze scrollbar, shared with the Up-next strip.
@@ -683,7 +631,7 @@ export const SectionTitle: React.FC<{ title: string; metrics: ISidebarMetrics }>
         <Typography
             level="title-sm"
             sx={{
-                fontSize: `${0.8 * metrics.fontScale}rem`,
+                fontSize: `${metrics.sectionTitleRem}rem`,
                 fontWeight: 800,
                 lineHeight: 1.2,
                 letterSpacing: "0.12em",
@@ -1015,8 +963,6 @@ const UnitStatsLayout: React.FC<{
         </>
     );
     const unitSynergies = ((unitProperties as UnitProperties).synergies as string[]) ?? [];
-    const auraTone =
-        team === TeamVals.LOWER ? TEAM_AURA.green : team === TeamVals.UPPER ? TEAM_AURA.red : TEAM_AURA.neutral;
     // Three stat rows, always — the well below scrolls if a creature carries more than nine.
     const statRowHeight = Math.round(metrics.statIconPx + 12);
     const statWellHeight = statRowHeight * 3 + STAT_ROW_GAP * 2;
@@ -1082,35 +1028,28 @@ const UnitStatsLayout: React.FC<{
                         ...teamAuraKeyframes,
                     }}
                 >
-                    {/* Team colour burns behind the art. Long, mutually indivisible periods so the layers
-                        never resynchronise into a visible pulse. */}
-                    <Box
-                        sx={auraFlameSx(
-                            flameWidth.outer,
-                            auraTone.outer,
-                            flameBlur.outer,
-                            "hocFlameA 23s ease-in-out infinite",
-                            1,
-                        )}
-                    />
-                    <Box
-                        sx={auraFlameSx(
-                            flameWidth.mid,
-                            auraTone.mid,
-                            flameBlur.mid,
-                            "hocFlameB 17s ease-in-out infinite",
-                            0.95,
-                        )}
-                    />
-                    <Box
-                        sx={auraFlameSx(
-                            flameWidth.inner,
-                            auraTone.inner,
-                            flameBlur.inner,
-                            "hocFlameA 13s ease-in-out infinite reverse",
-                            0.9,
-                        )}
-                    />
+                    {/* Synergies sit in the portrait block's top-left corner as a column, not as a section
+                        of their own. They are a standing property of the army rather than an effect on this
+                        stack, so they read better as a quiet marker beside the art than as a titled band
+                        competing with Buffs and Debuffs for the card's vertical space. */}
+                    {unitSynergies.length > 0 && (
+                        <Box
+                            sx={{
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                zIndex: 2,
+                                display: "flex",
+                                flexDirection: "column",
+                                alignItems: "flex-start",
+                                gap: `${Math.round(metrics.gapPx * 0.4)}px`,
+                                pointerEvents: "auto",
+                            }}
+                        >
+                            <SynergiesRow synergies={unitSynergies} column />
+                        </Box>
+                    )}
+
                     <Box
                         sx={{
                             // No circular clip and no frame: the art keeps its own silhouette, so wings,
@@ -1190,17 +1129,6 @@ const UnitStatsLayout: React.FC<{
                     />
                 </ScrollWell>
             </PanelSection>
-
-            {/* Synergies get their own section rather than sharing the Buffs well. They are not buffs: a buff
-                is something applied to THIS stack that will expire, while a synergy is a standing property of
-                the army's faction make-up. Mixed into one row they read as castable effects someone could
-                dispel, and the Buffs count stopped matching what was actually on the unit. Still driven by the
-                selected unit's own properties, so a green stack shows green's synergies and a red one red's. */}
-            {unitSynergies.length > 0 && (
-                <PanelSection title="Synergies" metrics={metrics}>
-                    <SynergiesRow synergies={unitSynergies} />
-                </PanelSection>
-            )}
 
             <PanelSection title="Buffs" metrics={metrics}>
                 <ScrollWell height={effectWellHeight}>

--- a/game/core/src/ui/LeftSideBar/UpNext.tsx
+++ b/game/core/src/ui/LeftSideBar/UpNext.tsx
@@ -2,7 +2,6 @@ import { TeamVals, TeamType } from "@heroesofcrypto/common";
 
 import Avatar from "@mui/joy/Avatar";
 import Box from "@mui/joy/Box";
-import Divider from "@mui/joy/Divider";
 import Stack from "@mui/joy/Stack";
 import Tooltip from "@mui/joy/Tooltip";
 import { AnimatePresence, motion } from "framer-motion";
@@ -16,6 +15,7 @@ import { resolveUnitImage } from "../unitImage";
 import { prefetchUnitAtlas, SectionTitle } from "./UnitStatsListItem";
 import { useSidebarMetrics } from "./sidebarMetrics";
 
+import { commonTooltipSx } from "./tooltipStyles";
 const stopImg = new URL("../../../images/stop.webp", import.meta.url).toString();
 const hourglassImg = images.hourglass;
 
@@ -27,17 +27,6 @@ const queueItemTransition = {
 };
 
 // --- Custom Style for "Heroes" Aesthetic Tooltips ---
-const commonTooltipSx = {
-    backgroundColor: "#2d1606", // Deep dark brown/wood
-    border: "2px solid #dcb158", // Metallic gold/bronze border
-    color: "#efe4cc", // Parchment/Cream text for contrast
-    borderRadius: "8px",
-    boxShadow: "0 6px 12px rgba(0,0,0,0.8)",
-    fontSize: "0.85rem",
-    fontWeight: 500,
-    maxWidth: "280px",
-    zIndex: 10000,
-};
 
 // The full-queue overlay is bound to the Alt key (see UpNextOverlay's `event.altKey` handler), but that
 // key is labelled Option on Apple keyboards — the hint has to name the key the player can actually see.
@@ -177,7 +166,6 @@ export const UpNext: React.FC = () => {
 
     return (
         <>
-            <Divider />
             <Tooltip
                 title={`Hold ${FULL_QUEUE_KEY_LABEL} to see the full turn order`}
                 placement="top"

--- a/game/core/src/ui/LeftSideBar/index.tsx
+++ b/game/core/src/ui/LeftSideBar/index.tsx
@@ -1,4 +1,4 @@
-import { UnitProperties, FactionType, FactionVals } from "@heroesofcrypto/common";
+import { TeamVals, UnitProperties, FactionType, FactionVals } from "@heroesofcrypto/common";
 import DiceIcon from "@mui/icons-material/Casino";
 import DashboardRoundedIcon from "@mui/icons-material/DashboardRounded";
 import FactoryRoundedIcon from "@mui/icons-material/FactoryRounded";
@@ -17,7 +17,32 @@ import { usePixiManager } from "../../pixi/PixiGameManager";
 // Near-black ground with a warm undertone, per the fight-sidebar handoff. No texture and no gold wash —
 // the board art has to stay the brightest thing on screen.
 export const SIDEBAR_BG = "#0b0806";
-export const SIDEBAR_BG_IMAGE = "linear-gradient(180deg, rgba(255,224,180,.02), rgba(0,0,0,.24))";
+const sidebarOverlayImage = new URL("../../../images/sidebar_overlay.webp", import.meta.url).toString();
+const greenOverlayImage = new URL("../../../images/overlay_green.webp", import.meta.url).toString();
+const redOverlayImage = new URL("../../../images/overlay_red.webp", import.meta.url).toString();
+
+// The team colour, swept diagonally off the bar's right edge — the placement this artwork was drawn for.
+// Rotated about its top-left so the band runs corner to corner behind the panel's content, and wider than
+// the bar so the rotation never exposes an edge. Fades rather than pops when the selection changes.
+const teamOverlaySx = {
+    position: "absolute",
+    width: "350px",
+    height: "100%",
+    top: 0,
+    right: -350,
+    transform: "translateZ(0) rotate(65deg)",
+    transformOrigin: "top left",
+    zIndex: 0,
+    pointerEvents: "none",
+    transition: "opacity 220ms ease-out",
+    willChange: "opacity",
+} as const;
+
+// The panel's carved-stone texture with the rebuild's subtle gradient layered ON TOP of it, rather than
+// instead of it. The rebuild dropped the texture for the gradient alone, which left the left bar flat
+// while the right bar (RightSideBar/index.tsx) still carried the same artwork -- the two stopped looking
+// like the same panel.
+export const SIDEBAR_BG_IMAGE = `linear-gradient(180deg, rgba(255,224,180,.02), rgba(0,0,0,.24)), url(${sidebarOverlayImage})`;
 import { UnitStatsListItem } from "./UnitStatsListItem";
 import { UpNext } from "./UpNext";
 import { computeSidebarMetrics, SidebarMetricsContext } from "./sidebarMetrics";
@@ -181,8 +206,27 @@ export default function LeftSideBar({ gameStarted, windowSize }: { gameStarted: 
                     willChange: "width",
                     backgroundColor: SIDEBAR_BG,
                     backgroundImage: SIDEBAR_BG_IMAGE,
+                    backgroundSize: "auto, cover",
+                    backgroundPosition: "center, center",
+                    backgroundRepeat: "no-repeat, no-repeat",
                 }}
             >
+                {/* Neutral (teamless) creatures get NEITHER band: the old code gated red on `team !== 2`,
+                    so a roster unit with no side was painted as an enemy. */}
+                <Box
+                    component="img"
+                    src={greenOverlayImage}
+                    alt=""
+                    aria-hidden
+                    sx={{ ...teamOverlaySx, opacity: unitProperties.team === TeamVals.LOWER ? 1 : 0 }}
+                />
+                <Box
+                    component="img"
+                    src={redOverlayImage}
+                    alt=""
+                    aria-hidden
+                    sx={{ ...teamOverlaySx, opacity: unitProperties.team === TeamVals.UPPER ? 1 : 0 }}
+                />
                 {/* The team colour is no longer a cloth banner across the bar — it is a fire-like aura
                     behind the portrait (see UnitStatsListItem). Synergies likewise moved into the unit's
                     Buffs block, which already scopes them to the right side. */}

--- a/game/core/src/ui/LeftSideBar/sidebarMetrics.ts
+++ b/game/core/src/ui/LeftSideBar/sidebarMetrics.ts
@@ -53,6 +53,8 @@ export interface ISidebarMetrics {
     statColumns: number;
     statIconPx: number;
     statFontRem: number;
+    /** Uppercase section headings: Abilities / Buffs / Debuffs / Up next. */
+    sectionTitleRem: number;
     /** Edge length of one ability tile, and how many fit per row. */
     abilityCell: number;
     abilitiesPerRow: number;
@@ -97,6 +99,10 @@ export function computeSidebarMetrics(
     const roomy = barSize >= 620;
     const fontScale = density === "micro" ? 0.85 : density === "narrow" ? 0.93 : roomy ? 1.12 : 1;
     const statFontRem = 0.75 * fontScale;
+    // Section headings are uppercase and widely letter-spaced, so they carry at a smaller size than body
+    // text and were previously oversized against the content they label. Derived from the same fontScale
+    // as everything else rather than a literal, and clamped so the micro density stays legible.
+    const sectionTitleRem = clamp(0.64 * fontScale, 0.54, 0.74);
     const statIconPx = Math.round(19 * fontScale);
 
     // Tiles stay in a comfortable 26–86px band; the row count follows from the width rather than a fixed
@@ -142,6 +148,7 @@ export function computeSidebarMetrics(
         statColumns,
         statIconPx,
         statFontRem,
+        sectionTitleRem,
         abilityCell,
         abilitiesPerRow,
         effectIcon,

--- a/game/core/src/ui/LeftSideBar/tooltipStyles.ts
+++ b/game/core/src/ui/LeftSideBar/tooltipStyles.ts
@@ -1,0 +1,19 @@
+/**
+ * The sidebar's tooltip look: dark wood, gold border, parchment text.
+ *
+ * One definition, because it was three — MessageBox, UpNext and UnitStatsListItem each carried a private
+ * copy, and SynergiesRow carried none at all, so synergy tooltips rendered in MUI's default styling and
+ * were the only ones in the panel that looked foreign. Anything in the sidebar that opens a Tooltip should
+ * pass this.
+ */
+export const commonTooltipSx = {
+    backgroundColor: "#2d1606", // Deep dark brown/wood
+    border: "2px solid #dcb158", // Metallic gold/bronze border
+    color: "#efe4cc", // Parchment/Cream text for contrast
+    borderRadius: "8px",
+    boxShadow: "0 6px 12px rgba(0,0,0,0.8)",
+    fontSize: "0.85rem",
+    fontWeight: 500,
+    maxWidth: "280px",
+    zIndex: 10000,
+};


### PR DESCRIPTION
Fixes found by running the fight sidebar after #119 and #120 landed. Two commits: what was missing, then what came out of looking at it live.

## Regressions from the sidebar rebuild (#119)

**Stat tooltips never opened.** Each stat is wrapped in a MUI `<Tooltip>`, which works by cloning its child and injecting hover/focus handlers plus a ref. `StatValue` was a plain component that forwarded neither, so all of it was dropped silently — no error, just nothing on hover. It now uses `forwardRef` and spreads the rest onto its Box.

**The magic-scroll count was gone entirely** — `ScrollIcon` was not even imported. It is the only readout of how many casts a spellcaster has left.

**The left bar lost its carved-stone texture**, replaced by a flat gradient, while the right bar still used the same artwork — so the two stopped looking like one panel. Restored, with the rebuild's gradient layered on top rather than instead of it.

**The team overlay artwork was dropped** for a generated glow behind the portrait. The green/red bands are back on the diagonal sweep off the bar's right edge, the placement they were drawn for.

I diffed the rebuild against its parent by icon and by component to find these. Two things looked dropped but were not: the Gray/Green/Red user icons belonged to the old collapsible header the rebuild replaced wholesale, and `SynergiesRow` was relocated rather than deleted.

## Neutral units were painted as enemies

`team === LOWER ? green : red` — a two-way ternary on a three-valued enum, so `NO_TEAM` took the else branch. Found in **four** places: the portrait aura, the stack-power pips, the roster card, and the old team overlay (which gated red on `team !== 2`). All now three-way, with teamless units getting neutral grey or no band at all.

## Layout and polish

- Armor and range armor share one cell the way morale and luck do. They are the same stat read against two attack types; splitting them made the pair read as unrelated, and the second cell only appeared for some creatures, which shifted every stat after it.
- Synergies moved out of the Buffs well into a column in the portrait's top-left corner. A buff is applied to this stack and expires; a synergy is a standing property of the army's faction make-up — mixed into one row they read as dispellable effects and the Buffs count stopped matching the unit.
- Section headings (Abilities / Buffs / Debuffs / Up next — all four share `SectionTitle`) are smaller, and come off a derived `sectionTitleRem` clamped for the micro density rather than an inline multiplier.
- Removed the divider that opened the Up-next strip; it drew a line directly under the turn timer.
- Unit names and stack counts on the board were the only text not in Open Sans — PixiJS `TextStyle` defaults to Arial when `fontFamily` is omitted, and all four board styles omitted it.
- Luck and morale tooltips now mention abilities power and post-narrowing steps.
- `commonTooltipSx` existed three times over, privately, and `SynergiesRow` had no copy — so synergy tooltips were the only ones in MUI's default styling. One `tooltipStyles.ts` now, imported by all four.

## Turn timer

It emptied to "0s" whenever `refreshVisibleStateIfNeeded` rebuilt the visible state — switching melee/ranged does exactly that — because the rebuild seeded the clock blank until the next 500ms tick. That function already preserves `hasFinished`, `teamWin`, `fightStats`, `teamTypeTurn`, `lapNumber` and `upNext`; the clock was simply missed. It now reads from `FightProperties`, which owns it, so the rebuilt state is correct immediately rather than one tick stale. This is in `Sandbox.ts`, so ranked gets it too.

The bar also drains amber to red instead of grey-white, so the colour carries the urgency the number was carrying alone.

## Verification

Typecheck clean, lint clean, 308/308 client tests. Checked by hand in a local sandbox built from `main` + #120.

## Known follow-ups, not in this PR

- **Action buttons** need their style and positioning reworked.
- **Stat modifier display was lost** — how buffs and auras affect a parameter is no longer shown. Worth treating as its own regression hunt, in the same spirit as the tooltips and the scroll count above.
- Buffs/debuffs wells are sized to exactly one row, so a long list scrolls with no affordance that there is more. Scrolling works, including touch on iPad (nothing sets `touch-action`), but nothing tells you to.