### PR TITLE
feat(ui): restyle right command deck and board controls

### DIFF
--- a/game/core/src/ui/PickAndBan/MapReveal.tsx
+++ b/game/core/src/ui/PickAndBan/MapReveal.tsx
@@ -28,13 +28,13 @@ const REVEAL_KEYFRAMES = `
 const MAP_FLOOR_KEY: Record<string, string> = {
     Standard: "background_stone_tiles_sinister_16x16",
     Lava: "background_stone_tiles_sinister_16x16",
-    Mountains: "background_stone_tiles_sinister_16x16",
+    Cemetery: "background_stone_tiles_sinister_16x16",
     Water: "background_stone_tiles_sinister_16x16",
 };
 
 const MAP_CENTER_OVERLAY: Record<string, string | undefined> = {
     Lava: "lava_256",
-    Mountains: "mountain_432_412",
+    Cemetery: "mountain_432_412",
     Water: "water_256",
 };
 

--- a/game/core/src/ui/PickAndBan/Timer.tsx
+++ b/game/core/src/ui/PickAndBan/Timer.tsx
@@ -1,5 +1,6 @@
 import { Chip } from "@mui/joy";
 import React from "react";
+import { HOC_NUMERIC_DIGITAL_FONT_FAMILY } from "../../fontFamilies";
 
 // Compact inline countdown that lives in the status row (next to the turn/upgrade chips).
 // Turns urgent (red, pulsing) only in the final seconds of your own turn — otherwise it's a
@@ -19,7 +20,7 @@ export const Timer = ({ localSeconds, isYourTurn }: { localSeconds: number; isYo
             variant={urgent ? "solid" : "soft"}
             color={urgent ? "danger" : "neutral"}
             sx={{
-                fontFamily: "DigitalDream, sans-serif",
+                fontFamily: HOC_NUMERIC_DIGITAL_FONT_FAMILY,
                 fontWeight: "bold",
                 minWidth: 56,
                 justifyContent: "center",

--- a/game/core/src/ui/PickAndBan/mapDisplay.test.ts
+++ b/game/core/src/ui/PickAndBan/mapDisplay.test.ts
@@ -7,7 +7,7 @@ describe("getMapDisplay (ranked map reveal presentation)", () => {
     it("maps each ranked grid type to its user-facing name and image", () => {
         expect(getMapDisplay(GridVals.NORMAL)).toMatchObject({ name: "Standard", imageKey: "board_icon" });
         expect(getMapDisplay(GridVals.LAVA_CENTER)).toMatchObject({ name: "Lava", imageKey: "lava_256" });
-        expect(getMapDisplay(GridVals.BLOCK_CENTER)).toMatchObject({ name: "Mountains", imageKey: "mountain_432_412" });
+        expect(getMapDisplay(GridVals.BLOCK_CENTER)).toMatchObject({ name: "Cemetery", imageKey: "mountain_432_412" });
     });
 
     it("still resolves Water (disabled in ranked, but mapped for robustness)", () => {

--- a/game/core/src/ui/PickAndBan/mapDisplay.ts
+++ b/game/core/src/ui/PickAndBan/mapDisplay.ts
@@ -28,10 +28,10 @@ export const getMapDisplay = (mapType: number): IMapDisplay | undefined => {
             };
         case GridVals.BLOCK_CENTER:
             return {
-                name: "Mountains",
+                name: "Cemetery",
                 imageKey: "mountain_432_412",
                 accent: "#d8b073",
-                blurb: "Two mountains flank a narrow central corridor.",
+                blurb: "Tombstones crowd a narrow central corridor.",
             };
         case GridVals.WATER_CENTER:
             return {

--- a/game/core/src/ui/RankedGameView.tsx
+++ b/game/core/src/ui/RankedGameView.tsx
@@ -57,7 +57,6 @@ import { getLocalModelOpponentConfig, isLocalModelAction } from "../scenes/Local
 import { authoritativeSnapshotToSandboxSceneState, RankedPlayScene } from "../scenes/RankedPlayScene";
 import type { IWindowSize } from "../scenes/VisibleState";
 import { FightFinishedOverlay } from "./FightFinishedOverlay";
-import { BoardEdgeTrim } from "./boardEdgeTrim";
 import LeftSideBar from "./LeftSideBar";
 import SynergiesRow from "./LeftSideBar/SynergiesRow";
 import { Main } from "./Main";
@@ -1680,7 +1679,6 @@ export const RankedGameView: React.FC<Props> = ({ gameId, userTeam, windowSize, 
                         around the same two sidebars — never drew it and the board simply ran into the
                         leather. It is anchored to the BOARD's edges, so it belongs beside the bars wherever
                         they are used. */}
-                    <BoardEdgeTrim windowSize={windowSize} />
                     <ViewerTeamContext.Provider value={viewerTeam}>
                         <LeftSideBar gameStarted={gameStarted} windowSize={windowSize} />
                     </ViewerTeamContext.Provider>

--- a/game/core/src/ui/RightSideBar/ArtifactToggler.tsx
+++ b/game/core/src/ui/RightSideBar/ArtifactToggler.tsx
@@ -4,6 +4,7 @@ import { Box, Divider, IconButton, Tooltip, Typography } from "@mui/joy";
 
 import { images } from "../../generated/image_imports";
 import { usePixiManager } from "../../pixi/PixiGameManager";
+import { hocDisplayFontFamily } from "../hocTheme";
 
 const imageFor = (imageKey: string): string | undefined => (images as Record<string, string>)[imageKey];
 
@@ -19,10 +20,20 @@ interface ArtifactRowProps {
 const ArtifactRow: React.FC<ArtifactRowProps> = ({ title, artifacts, selectedId, onSelect, isOpen }) => (
     <Box sx={{ width: "100%" }}>
         {/* Just a label now — the whole block opens from the Artifacts header above. */}
-        <Typography level="body-xs" sx={{ mb: isOpen ? 0.5 : 0, px: 0.5, display: isOpen ? "block" : "none" }}>
+        <Typography
+            level="body-xs"
+            sx={{ mb: isOpen ? 0.5 : 0, px: 0.5, display: isOpen ? "block" : "none", textAlign: "center" }}
+        >
             {title}
         </Typography>
-        <Box sx={{ display: isOpen ? "flex" : "none", flexWrap: "wrap", gap: 0.5 }}>
+        <Box
+            sx={{
+                display: isOpen ? "flex" : "none",
+                flexWrap: "wrap",
+                gap: 0.5,
+                "@media (max-height: 800px)": { gap: 0.25 },
+            }}
+        >
             {artifacts.map((artifact) => {
                 const src = imageFor(artifact.imageKey);
                 const isSelected = selectedId === artifact.id;
@@ -47,13 +58,36 @@ const ArtifactRow: React.FC<ArtifactRowProps> = ({ title, artifacts, selectedId,
                             color={isSelected ? "primary" : "neutral"}
                             // Clicking the selected artifact again clears the slot.
                             onClick={() => onSelect(isSelected ? Artifact.Tier1Artifact.NO_ARTIFACT : artifact.id)}
-                            sx={{ p: 0.25, borderRadius: "8px" }}
+                            sx={{
+                                p: 0.25,
+                                borderRadius: "8px",
+                                cursor: "default !important",
+                                overflow: "visible",
+                                "& img": {
+                                    transition: "transform 0.16s ease, filter 0.16s ease",
+                                    transformOrigin: "center",
+                                },
+                                "&:hover img": {
+                                    transform: "scale(1.05)",
+                                    filter: "drop-shadow(0 0 5px rgba(224, 176, 83, 0.72))",
+                                },
+                                "@media (max-height: 800px)": { p: "1px" },
+                            }}
                         >
                             {src ? (
-                                <img
+                                <Box
+                                    component="img"
                                     src={src}
                                     alt={artifact.name}
-                                    style={{ width: 48, height: 48, objectFit: "contain" }}
+                                    sx={{
+                                        width: 48,
+                                        height: 48,
+                                        objectFit: "contain",
+                                        "@media (max-height: 800px)": {
+                                            width: 33,
+                                            height: 33,
+                                        },
+                                    }}
                                 />
                             ) : (
                                 <Typography level="body-xs">{artifact.name}</Typography>
@@ -93,8 +127,24 @@ export const ArtifactToggler: React.FC<{
     };
 
     return (
-        <Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 0.5, mt: 0 }}>
-            <Divider />
+        <Box
+            sx={{
+                width: "100%",
+                display: "flex",
+                flexDirection: "column",
+                gap: 0,
+                mt: 0,
+                fontFamily: hocDisplayFontFamily,
+                fontWeight: 460,
+                fontSynthesis: "weight",
+                "& .MuiTypography-root": {
+                    fontFamily: hocDisplayFontFamily,
+                    fontWeight: 460,
+                    fontSynthesis: "weight",
+                },
+            }}
+        >
+            <Divider sx={{ borderColor: "rgba(112, 75, 42, 0.55)" }} />
             {/* One header for the whole block: clicking it reveals both tiers at once. Per-tier toggles meant
                 three things could be open at the same time and the bar grew past the fold; now it is two
                 states in the bar - augments or artifacts. */}
@@ -109,7 +159,7 @@ export const ArtifactToggler: React.FC<{
                     justifyContent: "space-between",
                     gap: 1,
                     px: 0.5,
-                    py: 0.5,
+                    py: 0.25,
                     background: "transparent",
                     border: "none",
                     cursor: "pointer",
@@ -117,7 +167,10 @@ export const ArtifactToggler: React.FC<{
                     "&:hover": { backgroundColor: "rgba(255,255,255,0.05)" },
                 }}
             >
-                <Typography level="title-sm" sx={{ color: "inherit" }}>
+                <Typography
+                    level="title-sm"
+                    sx={{ color: "inherit", fontSize: "1.1rem", letterSpacing: "0.06em", lineHeight: 1.25 }}
+                >
                     Artifacts
                 </Typography>
                 <Box
@@ -153,7 +206,7 @@ export const ArtifactToggler: React.FC<{
             {/* Closes the artifacts block off from whatever follows it — with the tiers collapsed, Tier 2's
                 row ran straight into the next team's flag header with nothing between them. Dimmer and
                 thinner than the divider that opens the section, so it reads as an end mark, not a new one. */}
-            <Divider sx={{ mt: 0.5, opacity: 0.45 }} />
+            <Divider sx={{ mt: 0, opacity: 0.45 }} />
         </Box>
     );
 };

--- a/game/core/src/ui/RightSideBar/FightControlToggler.tsx
+++ b/game/core/src/ui/RightSideBar/FightControlToggler.tsx
@@ -20,6 +20,63 @@ import MapSettingsRadioButtons from "./MapSettingsRadioButtons";
 import SandboxToggleContainer from "./SandboxToggleContainer";
 import { SynergySlots } from "./SynergySlots";
 import UnitSplitter from "./UnitSplitter";
+import {
+    hocColors,
+    hocDisplayFontFamily,
+    hocFontFamily,
+    hocSidebarSectionHeaderSx,
+    hocSidebarSectionSx,
+} from "../hocTheme";
+
+const sectionTitleSx = {
+    fontFamily: hocDisplayFontFamily,
+    fontSynthesis: "weight",
+    fontWeight: 800,
+    fontSize: "1.05rem",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    color: "#d8c29c",
+    textShadow: "0 2px 2px #000",
+} as const;
+
+const sectionIconSx = {
+    width: "41.4px",
+    height: "41.4px",
+    objectFit: "contain",
+    filter: "sepia(.18) saturate(.88) drop-shadow(0 2px 2px rgba(0,0,0,.8))",
+} as const;
+
+// Compact team pennants leave one uninterrupted row for all eight synergy seals.
+const teamFlagSx = {
+    width: "41.4px",
+    height: "48.3px",
+    flex: "0 0 41.4px",
+    objectFit: "contain",
+    filter: "none",
+    opacity: 0.9,
+} as const;
+
+const teamTitleSlotSx = {
+    flex: "0 0 72px",
+    width: "72px",
+    minWidth: 0,
+} as const;
+
+const teamSynergySlotSx = {
+    flex: "1 1 auto",
+    minWidth: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+} as const;
+
+const chevronSx = (open: boolean) => ({
+    width: "12px",
+    transform: open ? "none" : "rotate(180deg)",
+    transition: "transform 0.2s",
+    filter: "sepia(1) saturate(.55) brightness(1.18)",
+});
 
 const FightControlToggler: React.FC = () => {
     const [unitProperties, setUnitProperties] = useState({} as UnitProperties);
@@ -66,278 +123,235 @@ const FightControlToggler: React.FC = () => {
 
     return (
         /* @ts-ignore: style params */
-        <ListItem style={{ "--List-nestedInsetStart": "0px" }} nested>
-            <Toggler
-                defaultExpanded={true}
-                renderToggle={({ open, setOpen }) => {
-                    setOpenRefs.current.army = setOpen;
-                    return (
-                        <ListItemButton
-                            onClick={() => {
-                                if (!open) {
-                                    closeAllExcept("army");
-                                }
-                                setOpen(!open);
-                            }}
-                            sx={{
-                                py: 2, // 50% bigger Y-wise
-                                backgroundColor: open
-                                    ? "rgba(236, 240, 245, 0.05)" // Neutral lift; the ember cue lives in the label + icon
-                                    : "inherit",
-                                transition: "background-color 0.3s",
-                                "&:hover": {
-                                    backgroundColor: open ? "rgba(236, 240, 245, 0.08)" : "rgba(255, 255, 255, 0.05)",
-                                },
-                            }}
-                        >
-                            <Box
-                                component="img"
-                                src={images.army_icon}
-                                sx={{
-                                    width: "36px",
-                                    height: "36px",
-                                    filter: open ? "none" : "grayscale(100%)", // Optional: grayscale when closed
-                                    opacity: open ? 1 : 0.7,
+        <ListItem
+            style={{ "--List-nestedInsetStart": "0px" }}
+            nested
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 1.5,
+                "@media (max-height: 800px)": {
+                    gap: 0.5,
+                },
+                // Keep the image-backed button edges and the section frame fully inside the sidebar.
+                width: "98%",
+                ml: "2%",
+                mr: 0,
+                p: 0,
+                fontFamily: hocFontFamily,
+                fontWeight: 460,
+                fontSynthesis: "weight",
+                "& .MuiTypography-root, & input, & label": {
+                    fontWeight: 460,
+                    fontSynthesis: "weight",
+                },
+            }}
+        >
+            <Box sx={hocSidebarSectionSx("army")}>
+                <Toggler
+                    defaultExpanded={true}
+                    renderToggle={({ open, setOpen }) => {
+                        setOpenRefs.current.army = setOpen;
+                        return (
+                            <ListItemButton
+                                onClick={() => {
+                                    if (!open) {
+                                        closeAllExcept("army");
+                                    }
+                                    setOpen(!open);
                                 }}
-                            />
-                            <ListItemContent>
-                                <Typography
-                                    level="title-sm"
-                                    sx={{
-                                        color: open ? "#FF8F00" : "inherit",
-                                        fontWeight: open ? "xl" : "md",
-                                    }}
-                                >
-                                    Army
-                                </Typography>
-                            </ListItemContent>
-                            <Box
-                                component="img"
-                                src={images.tr_up}
                                 sx={{
-                                    width: "12px",
-                                    transform: open ? "none" : "rotate(180deg)",
-                                    transition: "transform 0.2s",
-                                    filter: open
-                                        ? "brightness(0) saturate(100%) invert(58%) sepia(91%) saturate(3089%) hue-rotate(2deg) brightness(103%) contrast(104%)"
-                                        : "none", // Gold filter approximation or just let it be
+                                    ...hocSidebarSectionHeaderSx,
+                                    px: 1.25,
+                                    backgroundColor: "transparent",
+                                    transform: open ? "scale(1.012)" : "scale(1)",
                                 }}
-                            />
-                        </ListItemButton>
-                    );
-                }}
-            >
-                <List>
-                    <UnitInputAndActions
-                        selectedUnitCount={unitProperties.amount_alive || 0}
-                        selectedTeamType={unitProperties.team}
-                    />
-                    <UnitSplitter totalUnits={unitProperties.amount_alive || 0} onSplit={handleSplit} />
-                </List>
-            </Toggler>
+                            >
+                                <Box
+                                    component="img"
+                                    src={images.army_icon}
+                                    sx={{ ...sectionIconSx, ml: "-4px", mr: "4px", opacity: open ? 1 : 0.72 }}
+                                />
+                                <ListItemContent>
+                                    <Typography
+                                        level="title-sm"
+                                        sx={{ ...sectionTitleSx, color: open ? hocColors.gold : sectionTitleSx.color }}
+                                    >
+                                        Army
+                                    </Typography>
+                                </ListItemContent>
+                                <Box component="img" src={images.tr_up} sx={chevronSx(open)} />
+                            </ListItemButton>
+                        );
+                    }}
+                >
+                    <List>
+                        <UnitInputAndActions
+                            selectedUnitCount={unitProperties.amount_alive || 0}
+                            selectedTeamType={unitProperties.team}
+                        />
+                        <UnitSplitter totalUnits={unitProperties.amount_alive || 0} onSplit={handleSplit} />
+                    </List>
+                </Toggler>
+            </Box>
 
-            <Toggler
-                defaultExpanded={false}
-                renderToggle={({ open, setOpen }) => {
-                    setOpenRefs.current.map = setOpen;
-                    return (
-                        <ListItemButton
-                            onClick={() => {
-                                if (!open) {
-                                    closeAllExcept("map");
-                                }
-                                setOpen(!open);
-                            }}
-                            sx={{
-                                py: 2, // 50% bigger Y-wise
-                                backgroundColor: open
-                                    ? "rgba(236, 240, 245, 0.05)" // Neutral lift; the ember cue lives in the label + icon
-                                    : "inherit",
-                                transition: "background-color 0.3s",
-                                "&:hover": {
-                                    backgroundColor: open ? "rgba(236, 240, 245, 0.08)" : "rgba(255, 255, 255, 0.05)",
-                                },
-                            }}
-                        >
-                            <Box
-                                component="img"
-                                src={images.board_icon}
-                                sx={{
-                                    width: "36px",
-                                    height: "36px",
-                                    filter: open ? "none" : "grayscale(100%)",
-                                    opacity: open ? 1 : 0.7,
+            <Box sx={hocSidebarSectionSx("board")}>
+                <Toggler
+                    defaultExpanded={false}
+                    renderToggle={({ open, setOpen }) => {
+                        setOpenRefs.current.map = setOpen;
+                        return (
+                            <ListItemButton
+                                onClick={() => {
+                                    if (!open) {
+                                        closeAllExcept("map");
+                                    }
+                                    setOpen(!open);
                                 }}
-                            />
-                            <ListItemContent>
-                                <Typography
-                                    level="title-sm"
-                                    sx={{
-                                        color: open ? "#FF8F00" : "inherit",
-                                        fontWeight: open ? "xl" : "md",
-                                    }}
-                                >
-                                    Board
-                                </Typography>
-                            </ListItemContent>
-                            <Box
-                                component="img"
-                                src={images.tr_up}
                                 sx={{
-                                    width: "12px",
-                                    transform: open ? "none" : "rotate(180deg)",
-                                    transition: "transform 0.2s",
-                                    filter: open
-                                        ? "brightness(0) saturate(100%) invert(58%) sepia(91%) saturate(3089%) hue-rotate(2deg) brightness(103%) contrast(104%)"
-                                        : "none",
+                                    ...hocSidebarSectionHeaderSx,
+                                    px: 1.25,
+                                    backgroundColor: "transparent",
+                                    transform: open ? "scale(1.012)" : "scale(1)",
                                 }}
-                            />
-                        </ListItemButton>
-                    );
-                }}
-            >
-                <List>
-                    <MapSettingsRadioButtons />
-                </List>
-            </Toggler>
+                            >
+                                <Box
+                                    component="img"
+                                    src={images.board_icon}
+                                    sx={{ ...sectionIconSx, ml: "-4px", mr: "4px", opacity: open ? 1 : 0.72 }}
+                                />
+                                <ListItemContent>
+                                    <Typography
+                                        level="title-sm"
+                                        sx={{ ...sectionTitleSx, color: open ? hocColors.gold : sectionTitleSx.color }}
+                                    >
+                                        Board
+                                    </Typography>
+                                </ListItemContent>
+                                <Box component="img" src={images.tr_up} sx={chevronSx(open)} />
+                            </ListItemButton>
+                        );
+                    }}
+                >
+                    <List>
+                        <MapSettingsRadioButtons />
+                    </List>
+                </Toggler>
+            </Box>
 
-            <Toggler
-                defaultExpanded={false}
-                renderToggle={({ open, setOpen }) => {
-                    setOpenRefs.current.red = setOpen;
-                    return (
-                        <ListItemButton
-                            onClick={() => {
-                                if (!open) {
-                                    closeAllExcept("red");
-                                }
-                                setOpen(!open);
-                            }}
-                            sx={{
-                                py: 2,
-                                backgroundColor: open ? "rgba(236, 240, 245, 0.05)" : "inherit",
-                                transition: "background-color 0.3s",
-                                "&:hover": {
-                                    backgroundColor: open ? "rgba(236, 240, 245, 0.08)" : "rgba(255, 255, 255, 0.05)",
-                                },
-                            }}
-                        >
-                            <Box
-                                component="img"
-                                src={images.flag_red_icon}
-                                sx={{
-                                    width: "36px",
-                                    height: "36px",
-                                    // The flag IS the team colour — it is what tells Reds from Greens at a
-                                    // glance. Graying it while the section is closed (which the Army and
-                                    // Board icons do, where colour carries nothing) left both sections
-                                    // reading as the same slate flag. Only the dimming is kept.
-                                    opacity: open ? 1 : 0.85,
+            <Box sx={hocSidebarSectionSx("team")}>
+                <Toggler
+                    defaultExpanded={false}
+                    renderToggle={({ open, setOpen }) => {
+                        setOpenRefs.current.red = setOpen;
+                        return (
+                            <ListItemButton
+                                onClick={() => {
+                                    if (!open) {
+                                        closeAllExcept("red");
+                                    }
+                                    setOpen(!open);
                                 }}
-                            />
-                            <ListItemContent>
-                                <Typography
-                                    level="title-sm"
+                                sx={{
+                                    ...hocSidebarSectionHeaderSx,
+                                    px: 1.25,
+                                    columnGap: "6px",
+                                    backgroundColor: "transparent",
+                                    transform: open ? "scale(1.012)" : "scale(1)",
+                                }}
+                            >
+                                <Box
+                                    component="img"
+                                    src={images.flag_red_icon}
                                     sx={{
-                                        color: open ? "#FF8F00" : "inherit",
-                                        fontWeight: open ? "xl" : "md",
+                                        ...teamFlagSx,
+                                        // The flag IS the team colour — it is what tells Reds from Greens at a
+                                        // glance. Graying it while the section is closed (which the Army and
+                                        // Board icons do, where colour carries nothing) left both sections
+                                        // reading as the same slate flag. Only the dimming is kept.
+                                        opacity: open ? 1 : teamFlagSx.opacity,
                                     }}
-                                >
-                                    Red
-                                </Typography>
-                            </ListItemContent>
-                            {/* The four racial synergies, right of the flag: visible whether the section is open
+                                />
+                                <ListItemContent sx={teamTitleSlotSx}>
+                                    <Typography
+                                        level="title-sm"
+                                        sx={{ ...sectionTitleSx, color: open ? "#dc9a78" : sectionTitleSx.color }}
+                                    >
+                                        Red
+                                    </Typography>
+                                </ListItemContent>
+                                {/* The four racial synergies, right of the flag: visible whether the section is open
                                 or shut, because they are army state rather than a setting inside it. */}
-                            <SynergySlots teamType={TeamVals.UPPER} />
-                            <Box
-                                component="img"
-                                src={images.tr_up}
-                                sx={{
-                                    width: "12px",
-                                    transform: open ? "none" : "rotate(180deg)",
-                                    transition: "transform 0.2s",
-                                    filter: open
-                                        ? "brightness(0) saturate(100%) invert(58%) sepia(91%) saturate(3089%) hue-rotate(2deg) brightness(103%) contrast(104%)"
-                                        : "none",
-                                }}
-                            />
-                        </ListItemButton>
-                    );
-                }}
-            >
-                <List>
-                    <SandboxToggleContainer side="red" teamType={TeamVals.UPPER} />
-                </List>
-            </Toggler>
+                                <Box sx={teamSynergySlotSx}>
+                                    <SynergySlots teamType={TeamVals.UPPER} size="clamp(16px, 1.35vw, 28px)" />
+                                </Box>
+                                <Box component="img" src={images.tr_up} sx={chevronSx(open)} />
+                            </ListItemButton>
+                        );
+                    }}
+                >
+                    <List>
+                        <SandboxToggleContainer side="red" teamType={TeamVals.UPPER} />
+                    </List>
+                </Toggler>
+            </Box>
 
-            <Toggler
-                defaultExpanded={false}
-                renderToggle={({ open, setOpen }) => {
-                    setOpenRefs.current.green = setOpen;
-                    return (
-                        <ListItemButton
-                            onClick={() => {
-                                if (!open) {
-                                    closeAllExcept("green");
-                                }
-                                setOpen(!open);
-                            }}
-                            sx={{
-                                py: 2,
-                                backgroundColor: open ? "rgba(236, 240, 245, 0.05)" : "inherit",
-                                transition: "background-color 0.3s",
-                                "&:hover": {
-                                    backgroundColor: open ? "rgba(236, 240, 245, 0.08)" : "rgba(255, 255, 255, 0.05)",
-                                },
-                            }}
-                        >
-                            <Box
-                                component="img"
-                                src={images.flag_green_icon}
-                                sx={{
-                                    width: "36px",
-                                    height: "36px",
-                                    // The flag IS the team colour — it is what tells Reds from Greens at a
-                                    // glance. Graying it while the section is closed (which the Army and
-                                    // Board icons do, where colour carries nothing) left both sections
-                                    // reading as the same slate flag. Only the dimming is kept.
-                                    opacity: open ? 1 : 0.85,
+            <Box sx={hocSidebarSectionSx("team")}>
+                <Toggler
+                    defaultExpanded={false}
+                    renderToggle={({ open, setOpen }) => {
+                        setOpenRefs.current.green = setOpen;
+                        return (
+                            <ListItemButton
+                                onClick={() => {
+                                    if (!open) {
+                                        closeAllExcept("green");
+                                    }
+                                    setOpen(!open);
                                 }}
-                            />
-                            <ListItemContent>
-                                <Typography
-                                    level="title-sm"
+                                sx={{
+                                    ...hocSidebarSectionHeaderSx,
+                                    px: 1.25,
+                                    columnGap: "6px",
+                                    backgroundColor: "transparent",
+                                    transform: open ? "scale(1.012)" : "scale(1)",
+                                }}
+                            >
+                                <Box
+                                    component="img"
+                                    src={images.flag_green_icon}
                                     sx={{
-                                        color: open ? "#FF8F00" : "inherit",
-                                        fontWeight: open ? "xl" : "md",
+                                        ...teamFlagSx,
+                                        // The flag IS the team colour — it is what tells Reds from Greens at a
+                                        // glance. Graying it while the section is closed (which the Army and
+                                        // Board icons do, where colour carries nothing) left both sections
+                                        // reading as the same slate flag. Only the dimming is kept.
+                                        opacity: open ? 1 : teamFlagSx.opacity,
                                     }}
-                                >
-                                    Green
-                                </Typography>
-                            </ListItemContent>
-                            {/* The four racial synergies, right of the flag: visible whether the section is open
+                                />
+                                <ListItemContent sx={teamTitleSlotSx}>
+                                    <Typography
+                                        level="title-sm"
+                                        sx={{ ...sectionTitleSx, color: open ? "#9fc487" : sectionTitleSx.color }}
+                                    >
+                                        Green
+                                    </Typography>
+                                </ListItemContent>
+                                {/* The four racial synergies, right of the flag: visible whether the section is open
                                 or shut, because they are army state rather than a setting inside it. */}
-                            <SynergySlots teamType={TeamVals.LOWER} />
-                            <Box
-                                component="img"
-                                src={images.tr_up}
-                                sx={{
-                                    width: "12px",
-                                    transform: open ? "none" : "rotate(180deg)",
-                                    transition: "transform 0.2s",
-                                    filter: open
-                                        ? "brightness(0) saturate(100%) invert(58%) sepia(91%) saturate(3089%) hue-rotate(2deg) brightness(103%) contrast(104%)"
-                                        : "none",
-                                }}
-                            />
-                        </ListItemButton>
-                    );
-                }}
-            >
-                <List>
-                    <SandboxToggleContainer side="green" teamType={TeamVals.LOWER} />
-                </List>
-            </Toggler>
+                                <Box sx={teamSynergySlotSx}>
+                                    <SynergySlots teamType={TeamVals.LOWER} size="clamp(16px, 1.35vw, 28px)" />
+                                </Box>
+                                <Box component="img" src={images.tr_up} sx={chevronSx(open)} />
+                            </ListItemButton>
+                        );
+                    }}
+                >
+                    <List>
+                        <SandboxToggleContainer side="green" teamType={TeamVals.LOWER} />
+                    </List>
+                </Toggler>
+            </Box>
         </ListItem>
     );
 };

--- a/game/core/src/ui/RightSideBar/MapSettingsRadioButtons.tsx
+++ b/game/core/src/ui/RightSideBar/MapSettingsRadioButtons.tsx
@@ -6,6 +6,7 @@ import RadioGroup from "@mui/joy/RadioGroup";
 import Radio from "@mui/joy/Radio";
 import Button from "@mui/joy/Button";
 import { usePixiManager } from "../../pixi/PixiGameManager";
+import { hocDisplayFontFamily, hocFantasyRadioSx, hocSidebarImageButtonSx } from "../hocTheme";
 
 const MapSettingsRadioButtons: React.FC = () => {
     const [gridType, setGridType] = useState<GridType>(GridVals.NORMAL);
@@ -44,7 +45,17 @@ const MapSettingsRadioButtons: React.FC = () => {
     };
 
     return (
-        <Box sx={{ padding: 1, display: "flex" }}>
+        <Box
+            sx={{
+                ...hocFantasyRadioSx,
+                m: 1.25,
+                p: 1.25,
+                display: "flex",
+                border: "1px solid rgba(126,83,44,.45)",
+                background: "rgba(0,0,0,.28)",
+                boxShadow: "inset 0 0 13px rgba(0,0,0,.75)",
+            }}
+        >
             {/* Left side: Radio buttons */}
             <Box sx={{ flex: 1 }}>
                 <FormControl>
@@ -56,7 +67,7 @@ const MapSettingsRadioButtons: React.FC = () => {
                     >
                         <Radio
                             value={GridVals.NORMAL}
-                            label="Normal"
+                            label="NORMAL"
                             sx={{
                                 color: "rgba(255, 143, 0, 0.5)",
                                 "&.Mui-checked": {
@@ -64,6 +75,9 @@ const MapSettingsRadioButtons: React.FC = () => {
                                 },
                                 "& .MuiTypography-root": {
                                     color: "rgba(255, 143, 0, 0.5)",
+                                    fontFamily: hocDisplayFontFamily,
+                                    fontWeight: 460,
+                                    fontSynthesis: "weight",
                                 },
                                 "&.Mui-checked .MuiTypography-root": {
                                     color: "#FF8F00",
@@ -76,7 +90,7 @@ const MapSettingsRadioButtons: React.FC = () => {
                         />
                         <Radio
                             value={GridVals.LAVA_CENTER}
-                            label="Lava"
+                            label="LAVA"
                             sx={{
                                 color: "rgba(255, 143, 0, 0.5)",
                                 "&.Mui-checked": {
@@ -84,6 +98,9 @@ const MapSettingsRadioButtons: React.FC = () => {
                                 },
                                 "& .MuiTypography-root": {
                                     color: "rgba(255, 143, 0, 0.5)",
+                                    fontFamily: hocDisplayFontFamily,
+                                    fontWeight: 460,
+                                    fontSynthesis: "weight",
                                 },
                                 "&.Mui-checked .MuiTypography-root": {
                                     color: "#FF8F00",
@@ -96,7 +113,7 @@ const MapSettingsRadioButtons: React.FC = () => {
                         />
                         <Radio
                             value={GridVals.BLOCK_CENTER}
-                            label="Mountains"
+                            label="CEMETERY"
                             sx={{
                                 color: "rgba(255, 143, 0, 0.5)",
                                 "&.Mui-checked": {
@@ -104,6 +121,9 @@ const MapSettingsRadioButtons: React.FC = () => {
                                 },
                                 "& .MuiTypography-root": {
                                     color: "rgba(255, 143, 0, 0.5)",
+                                    fontFamily: hocDisplayFontFamily,
+                                    fontWeight: 460,
+                                    fontSynthesis: "weight",
                                 },
                                 "&.Mui-checked .MuiTypography-root": {
                                     color: "#FF8F00",
@@ -122,20 +142,15 @@ const MapSettingsRadioButtons: React.FC = () => {
             {/* Right side: Random button */}
             <Box sx={{ flex: 1, display: "flex", justifyContent: "center", alignItems: "center" }}>
                 <Button
-                    variant="outlined"
+                    variant="plain"
                     onClick={handleRandomButtonClick}
                     sx={{
-                        height: "100%",
-                        width: "100%",
-                        borderColor: "#FF8F00",
-                        color: "#FF8F00",
-                        "&:hover": {
-                            borderColor: "#FF8F00",
-                            backgroundColor: "rgba(255, 143, 0, 0.1)",
-                        },
-                        "&:active": {
-                            backgroundColor: "rgba(255, 143, 0, 0.2)",
-                        },
+                        ...hocSidebarImageButtonSx("neutral"),
+                        // Keep the label and right edge fixed; the plate is 25% shorter and grows 5% leftward.
+                        height: "48.3px",
+                        width: "105%",
+                        transform: "translateX(-5%)",
+                        minHeight: 0,
                     }}
                 >
                     Random

--- a/game/core/src/ui/RightSideBar/SandboxToggleContainer.tsx
+++ b/game/core/src/ui/RightSideBar/SandboxToggleContainer.tsx
@@ -12,7 +12,7 @@ import React, { useState } from "react";
 import { Box, FormControl, FormLabel, IconButton, Radio, RadioGroup, Sheet, Tooltip, Typography } from "@mui/joy";
 import { usePixiManager } from "../../pixi/PixiGameManager";
 import { images } from "../../generated/image_imports";
-import { hocColors } from "../hocTheme";
+import { hocColors, hocDisplayFontFamily, hocFantasyRadioSx } from "../hocTheme";
 import { ArtifactToggler } from "./ArtifactToggler";
 
 const augmentBoardImg = new URL("../../../images/board_augment_256.webp", import.meta.url).toString();
@@ -44,6 +44,41 @@ const AUGMENT_BUTTONS: ReadonlyArray<{
 // rendered underneath the frame and was sliced off at the panel's edge.
 const AUGMENT_TOOLTIP_Z = 10000;
 
+// The setup deck is intentionally non-scrollable. Keep every augment choice compact enough that the
+// longest panel (Sniper, with four rows) still leaves room for both team headers at laptop heights.
+const compactAugmentSheetSx = {
+    ...hocFantasyRadioSx,
+    padding: 0.5,
+    borderRadius: "md",
+    borderColor: "rgba(112, 75, 42, 0.55)",
+    fontWeight: 530,
+    fontSynthesis: "weight",
+    "& .MuiFormLabel-root": {
+        marginBottom: 0.25,
+        lineHeight: 1.15,
+        fontWeight: 530,
+        fontSynthesis: "weight",
+    },
+    "& .MuiRadioGroup-root": {
+        gap: 0,
+    },
+    "& .MuiRadio-root": {
+        minHeight: "26px",
+        paddingBlock: 0,
+        fontSize: "1.00625rem",
+        lineHeight: 1.15,
+        alignItems: "center",
+    },
+    "& .MuiRadio-label": {
+        display: "flex",
+        alignItems: "center",
+        minHeight: "26px",
+        lineHeight: 1.15,
+        fontWeight: 530,
+        fontSynthesis: "weight",
+    },
+} as const;
+
 const PlacementToggler = ({
     title,
     teamType,
@@ -66,14 +101,8 @@ const PlacementToggler = ({
     };
 
     return (
-        <Box sx={{ marginBottom: 0.5 }}>
-            <Sheet
-                variant="outlined"
-                sx={{
-                    padding: 2,
-                    borderRadius: "md",
-                }}
-            >
+        <Box sx={{ width: "100%", mx: "auto", marginBottom: 0 }}>
+            <Sheet variant="outlined" sx={compactAugmentSheetSx}>
                 <FormControl>
                     <FormLabel>Augment Board Placement</FormLabel>
                     <RadioGroup
@@ -135,16 +164,10 @@ const ArmorToggler = ({
     };
 
     return (
-        <Box sx={{ marginBottom: 0.5 }}>
+        <Box sx={{ width: "100%", mx: "auto", marginBottom: 0 }}>
             {/* Remaining Points Text (Orange and Bold) */}
             {/* The Toggler Sheet */}
-            <Sheet
-                variant="outlined"
-                sx={{
-                    padding: 2,
-                    borderRadius: "md",
-                }}
-            >
+            <Sheet variant="outlined" sx={compactAugmentSheetSx}>
                 <FormControl>
                     <FormLabel>Augment Armor</FormLabel>
                     <RadioGroup
@@ -207,16 +230,10 @@ const MightToggler = ({
     };
 
     return (
-        <Box sx={{ marginBottom: 0.5 }}>
+        <Box sx={{ width: "100%", mx: "auto", marginBottom: 0 }}>
             {/* Remaining Points Text (Orange and Bold) */}
             {/* The Toggler Sheet */}
-            <Sheet
-                variant="outlined"
-                sx={{
-                    padding: 2,
-                    borderRadius: "md",
-                }}
-            >
+            <Sheet variant="outlined" sx={compactAugmentSheetSx}>
                 <FormControl>
                     <FormLabel>Augment Might</FormLabel>
                     <RadioGroup
@@ -279,16 +296,10 @@ const EmpowerToggler = ({
     };
 
     return (
-        <Box sx={{ marginBottom: 0.5 }}>
+        <Box sx={{ width: "100%", mx: "auto", marginBottom: 0 }}>
             {/* Remaining Points Text (Orange and Bold) */}
             {/* The Toggler Sheet */}
-            <Sheet
-                variant="outlined"
-                sx={{
-                    padding: 2,
-                    borderRadius: "md",
-                }}
-            >
+            <Sheet variant="outlined" sx={compactAugmentSheetSx}>
                 <FormControl>
                     <FormLabel>Augment Empower</FormLabel>
                     <RadioGroup
@@ -351,14 +362,8 @@ const SniperToggler = ({
     };
 
     return (
-        <Box sx={{ marginBottom: 0.5 }}>
-            <Sheet
-                variant="outlined"
-                sx={{
-                    padding: 2,
-                    borderRadius: "md",
-                }}
-            >
+        <Box sx={{ width: "100%", mx: "auto", marginBottom: 0 }}>
+            <Sheet variant="outlined" sx={compactAugmentSheetSx}>
                 <FormControl>
                     <FormLabel>Augment Sniper</FormLabel>
                     <RadioGroup
@@ -427,14 +432,8 @@ const MovementToggler = ({
     };
 
     return (
-        <Box sx={{ marginBottom: 0.5 }}>
-            <Sheet
-                variant="outlined"
-                sx={{
-                    padding: 2,
-                    borderRadius: "md",
-                }}
-            >
+        <Box sx={{ width: "100%", mx: "auto", marginBottom: 0 }}>
+            <Sheet variant="outlined" sx={compactAugmentSheetSx}>
                 <FormControl>
                     <FormLabel>Augment Movement</FormLabel>
                     <RadioGroup
@@ -532,7 +531,22 @@ const SandboxToggleContainer = ({
     };
 
     return (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, paddingTop: 2 }}>
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 0.5,
+                paddingTop: 0.25,
+                fontFamily: hocDisplayFontFamily,
+                fontWeight: 460,
+                fontSynthesis: "weight",
+                "& .MuiTypography-root, & .MuiFormLabel-root": {
+                    fontFamily: hocDisplayFontFamily,
+                    fontWeight: 460,
+                    fontSynthesis: "weight",
+                },
+            }}
+        >
             {/* Header in the same shape as Artifacts below: a title and a collapse chevron, so the two
                 blocks in this bar read as a pair rather than one titled section and one loose icon row. */}
             <Box
@@ -546,7 +560,7 @@ const SandboxToggleContainer = ({
                     justifyContent: "space-between",
                     gap: 1,
                     px: 0.5,
-                    py: 0.5,
+                    py: 0.25,
                     background: "transparent",
                     border: "none",
                     cursor: "pointer",
@@ -554,7 +568,10 @@ const SandboxToggleContainer = ({
                     "&:hover": { backgroundColor: "rgba(255,255,255,0.05)" },
                 }}
             >
-                <Typography level="title-sm" sx={{ color: "inherit" }}>
+                <Typography
+                    level="title-sm"
+                    sx={{ color: "inherit", fontSize: "1.1rem", letterSpacing: "0.06em", lineHeight: 1.25 }}
+                >
                     Augments
                 </Typography>
                 <Box
@@ -579,28 +596,57 @@ const SandboxToggleContainer = ({
                     Written as a map over AUGMENT_BUTTONS rather than six near-identical Tooltip/IconButton
                     blocks: they differed only in image, label and key, and the selected-state styling had to
                     be repeated verbatim in each one. */}
-                    <Box sx={{ display: "flex", justifyContent: "center", gap: 0, flexWrap: "nowrap" }}>
+                    <Box
+                        sx={{
+                            display: "flex",
+                            justifyContent: "center",
+                            gap: 0,
+                            flexWrap: "nowrap",
+                        }}
+                    >
                         {AUGMENT_BUTTONS.map(({ kind, title, alt, img }) => {
                             const selected = togglerType === kind;
                             return (
                                 <Tooltip key={kind} title={title} placement="right" sx={{ zIndex: AUGMENT_TOOLTIP_Z }}>
                                     <IconButton
                                         sx={{
-                                            p: 0.25,
+                                            px: 0.25,
+                                            py: 0.75,
+                                            my: -0.5,
                                             minWidth: 0,
                                             flex: "1 1 0",
+                                            cursor: "default !important",
                                             // The open augment used to be marked by brightness alone (1.2 vs
                                             // 0.6), which on six busy 48px illustrations was easy to miss —
                                             // several of them are bright to begin with. An amber frame in the
                                             // panel's own accent says which one is open at a glance. The
                                             // border is always present and merely transparent when idle, so
                                             // selecting an icon cannot nudge the row's layout.
-                                            borderRadius: "8px",
-                                            border: "1px solid",
-                                            borderColor: selected ? hocColors.orange : "transparent",
+                                            position: "relative",
+                                            overflow: "hidden",
+                                            isolation: "isolate",
+                                            zIndex: selected ? 1 : 0,
+                                            borderRadius: "3px",
+                                            border: "1px solid transparent !important",
                                             backgroundColor: selected ? "rgba(255, 143, 0, 0.12)" : "transparent",
                                             boxShadow: selected ? "0 0 8px rgba(255, 143, 0, 0.45)" : "none",
                                             transition: "background-color 0.15s, box-shadow 0.15s",
+                                            // Draw the selected ring above the artwork. A normal button border
+                                            // sat underneath the full-bleed image, leaving only its side rails
+                                            // visible; this overlay keeps all four sides equally clear.
+                                            "&::after": {
+                                                content: '""',
+                                                position: "absolute",
+                                                inset: 0,
+                                                boxSizing: "border-box",
+                                                zIndex: 10,
+                                                pointerEvents: "none",
+                                                borderRadius: "inherit",
+                                                border: selected
+                                                    ? `2px solid ${hocColors.orange}`
+                                                    : "2px solid transparent",
+                                                boxShadow: selected ? "inset 0 0 5px rgba(255, 194, 92, 0.28)" : "none",
+                                            },
                                             // Hover deliberately paints NO frame. The frame means "this
                                             // augment's panel is the open one", and lighting one under the
                                             // cursor put that mark on two icons at once. Hover grows the art
@@ -610,6 +656,7 @@ const SandboxToggleContainer = ({
                                             "&:hover": {
                                                 backgroundColor: selected ? "rgba(255, 143, 0, 0.12)" : "transparent",
                                             },
+                                            "& img": { transform: selected ? "scale(1.15)" : "scale(1)" },
                                             "&:hover img": { transform: "scale(1.15)" },
                                         }}
                                         onClick={() => handleAugmentClick(kind)}
@@ -631,7 +678,15 @@ const SandboxToggleContainer = ({
                             );
                         })}
                     </Box>
-                    <Typography sx={{ color: "orange", fontWeight: "bold", paddingTop: 1 }}>
+                    <Typography
+                        sx={{
+                            width: "93%",
+                            mx: "auto",
+                            color: "orange",
+                            fontWeight: "bold",
+                            paddingTop: 0,
+                        }}
+                    >
                         Remaining Points: {totalPoints}
                     </Typography>
                     {togglerType === "Placement" && (

--- a/game/core/src/ui/RightSideBar/SynergySlots.tsx
+++ b/game/core/src/ui/RightSideBar/SynergySlots.tsx
@@ -44,7 +44,7 @@ const levelsBySynergy = (
     return levels;
 };
 
-export const SynergySlots: React.FC<{ teamType: TeamType; size?: number }> = ({ teamType, size = 22 }) => {
+export const SynergySlots: React.FC<{ teamType: TeamType; size?: number | string }> = ({ teamType, size = 22 }) => {
     const manager = usePixiManager();
     const [possible, setPossible] = useState<Map<TeamType, SynergyWithLevel[]> | null>(null);
     useEffect(() => {
@@ -59,7 +59,18 @@ export const SynergySlots: React.FC<{ teamType: TeamType; size?: number }> = ({ 
     const levels = levelsBySynergy(possible, teamType);
 
     return (
-        <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 0.25 }}>
+        <Box
+            sx={{
+                display: "flex",
+                flex: "1 1 auto",
+                minWidth: 0,
+                flexWrap: "nowrap",
+                alignItems: "center",
+                justifyContent: "space-between",
+                width: "100%",
+                gap: 0.2,
+            }}
+        >
             {SYNERGIES.map(({ key, label, variant }) => {
                 const level = levels[key] ?? 0;
                 const isActive = level > 0;
@@ -91,7 +102,12 @@ export const SynergySlots: React.FC<{ teamType: TeamType; size?: number }> = ({ 
                             alt={label}
                             sx={{
                                 width: size,
-                                height: size,
+                                height: "auto",
+                                maxWidth: size,
+                                minWidth: 0,
+                                aspectRatio: "1 / 1",
+                                objectFit: "contain",
+                                flex: `1 1 ${typeof size === "number" ? `${size}px` : size}`,
                                 filter: isActive ? "none" : "grayscale(100%) brightness(0.55)",
                                 opacity: isActive ? 1 : 0.5,
                                 transition: "filter 0.25s, opacity 0.25s",

--- a/game/core/src/ui/RightSideBar/UnitInputAndActions.tsx
+++ b/game/core/src/ui/RightSideBar/UnitInputAndActions.tsx
@@ -8,7 +8,7 @@ import Typography from "@mui/joy/Typography";
 import { TeamType } from "@heroesofcrypto/common";
 
 import { usePixiManager } from "../../pixi/PixiGameManager";
-import { hocActionPrimaryButtonSx, hocActionSoftButtonSx } from "../hocTheme";
+import { hocDisplayFontFamily, hocSidebarImageButtonSx } from "../hocTheme";
 
 const DEFAULT_NUMBER_OF_UNITS_TO_ACCEPT = 1;
 
@@ -148,7 +148,17 @@ const UnitInputAndActions = ({
     return (
         <Box sx={{ width: "100%", marginTop: 2 }}>
             {slots !== null && (
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1, paddingTop: 1, paddingBottom: 2 }}>
+                <Box
+                    sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        width: "93%",
+                        mx: "auto",
+                        paddingTop: 1,
+                        paddingBottom: 2,
+                    }}
+                >
                     <Typography
                         sx={{
                             color: "rgba(255, 143, 0, 0.85)",
@@ -156,6 +166,8 @@ const UnitInputAndActions = ({
                             fontSize: "0.8rem",
                             textTransform: "uppercase",
                             letterSpacing: "0.04em",
+                            fontFamily: hocDisplayFontFamily,
+                            fontSynthesis: "none",
                         }}
                     >
                         Slots left
@@ -171,6 +183,7 @@ const UnitInputAndActions = ({
                             borderRadius: "8px",
                             border: "1.5px solid rgba(255, 143, 0, 0.5)",
                             backgroundColor: "rgba(255, 143, 0, 0.12)",
+                            fontFamily: hocDisplayFontFamily,
                             ...(pulse
                                 ? { animation: `${pulse.dir === "up" ? "hocSlotsUp" : "hocSlotsDown"} 0.45s ease-out` }
                                 : {}),
@@ -201,18 +214,27 @@ const UnitInputAndActions = ({
                                 fontSize: "1.1rem",
                                 lineHeight: 1,
                                 color: slots.remaining === 0 ? "#ff5a5a" : "#FFB74D",
+                                fontFamily: hocDisplayFontFamily,
+                                fontSynthesis: "none",
                             }}
                         >
                             {slots.remaining}
                         </Typography>
-                        <Typography sx={{ fontSize: "0.75rem", color: "rgba(255, 255, 255, 0.55)" }}>
+                        <Typography
+                            sx={{
+                                fontSize: "0.75rem",
+                                color: "rgba(255, 255, 255, 0.55)",
+                                fontFamily: hocDisplayFontFamily,
+                                fontSynthesis: "none",
+                            }}
+                        >
                             / {slots.max}
                         </Typography>
                     </Box>
                 </Box>
             )}
 
-            <Stack spacing={1}>
+            <Stack spacing={2}>
                 <Input
                     type="number"
                     value={unitCount}
@@ -220,18 +242,27 @@ const UnitInputAndActions = ({
                     placeholder="# of units"
                     variant="outlined"
                     sx={{
-                        color: "rgba(255, 143, 0, 0.5)",
-                        borderColor: "rgba(255, 143, 0, 0.5)",
-                        "--Input-focusedHighlight": "#FF8F00",
+                        width: "93%",
+                        mx: "auto",
+                        transform: "translateX(clamp(0px, calc((100vw - 1422px) * 0.04), 24px))",
+                        minHeight: "48px",
+                        borderRadius: 0,
+                        color: "#d8c29c",
+                        background: "linear-gradient(180deg, rgba(6,6,6,.78), rgba(18,15,12,.78))",
+                        borderColor: "rgba(116, 78, 43, .58)",
+                        boxShadow: "inset 0 0 12px rgba(0,0,0,.8)",
+                        fontFamily: hocDisplayFontFamily,
+                        fontSynthesis: "none",
+                        "--Input-focusedHighlight": "#9b693a",
                         "--Input-focusedThickness": "2px",
                         "&:hover": {
-                            borderColor: "#FF8F00",
-                            color: "#FF8F00",
+                            borderColor: "#b17a43",
+                            color: "#e5c594",
                         },
                         "&:focus-within": {
-                            borderColor: "#FF8F00",
-                            color: "#FF8F00",
-                            "--Input-focusedHighlight": "#FF8F00",
+                            borderColor: "#b17a43",
+                            color: "#e5c594",
+                            "--Input-focusedHighlight": "#b17a43",
                         },
                         "&::before": {
                             boxShadow: "none !important",
@@ -241,18 +272,22 @@ const UnitInputAndActions = ({
                             boxShadow: "0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight) !important",
                         },
                         "&.Mui-focused": {
-                            borderColor: "#FF8F00",
-                            color: "#FF8F00",
+                            borderColor: "#b17a43",
+                            color: "#e5c594",
                             boxShadow: "none",
                             outline: "none",
                             "& input::placeholder": {
-                                color: "#FF8F00",
+                                color: "#d8c29c",
                                 opacity: 0.6,
                             },
                         },
                         "& input::placeholder": {
-                            color: "rgba(255, 143, 0, 0.5)",
+                            color: "rgba(216,194,156,.58)",
                             opacity: 0.6,
+                        },
+                        "& input": {
+                            fontFamily: hocDisplayFontFamily,
+                            fontSynthesis: "none",
                         },
                         transition: "all 0.2s ease",
                     }}
@@ -262,7 +297,15 @@ const UnitInputAndActions = ({
                         },
                     }}
                 />
-                <Stack direction="row" spacing={1.5}>
+                <Stack
+                    direction="row"
+                    spacing={2}
+                    sx={{
+                        width: "93%",
+                        mx: "auto",
+                        transform: "translateX(clamp(0px, calc((100vw - 1422px) * 0.04), 24px))",
+                    }}
+                >
                     <Tooltip title="Accept (A)" placement="top" sx={shortcutTooltipSx}>
                         <Button
                             variant="plain"
@@ -270,7 +313,7 @@ const UnitInputAndActions = ({
                             onClick={() => {
                                 handleAccept(parseInt(unitCount) || DEFAULT_NUMBER_OF_UNITS_TO_ACCEPT);
                             }}
-                            sx={{ ...hocActionPrimaryButtonSx, flex: 1, minWidth: 0 }}
+                            sx={{ ...hocSidebarImageButtonSx("primary"), flex: 1, minWidth: 0 }}
                         >
                             Accept
                         </Button>
@@ -282,7 +325,7 @@ const UnitInputAndActions = ({
                             onClick={() => {
                                 manager.Clone();
                             }}
-                            sx={{ ...hocActionSoftButtonSx, flex: 1, minWidth: 0 }}
+                            sx={{ ...hocSidebarImageButtonSx("neutral"), flex: 1, minWidth: 0 }}
                         >
                             Clone
                         </Button>

--- a/game/core/src/ui/RightSideBar/UnitSplitter.tsx
+++ b/game/core/src/ui/RightSideBar/UnitSplitter.tsx
@@ -7,7 +7,7 @@ import Slider from "@mui/joy/Slider";
 import Button from "@mui/joy/Button";
 import Tooltip from "@mui/joy/Tooltip";
 import { images } from "../../generated/image_imports";
-import { hocActionDangerButtonSx, hocActionSoftButtonSx } from "../hocTheme";
+import { hocDisplayFontFamily, hocSidebarImageButtonSx } from "../hocTheme";
 
 interface IUnitSplitterProps {
     totalUnits: number;
@@ -36,6 +36,7 @@ function isEditableShortcutTarget(target: EventTarget | null): boolean {
 const UnitSplitter = ({ totalUnits, onSplit }: IUnitSplitterProps) => {
     const manager = usePixiManager();
     const [splitValue, setSplitValue] = React.useState(1); // Start with minimum value
+    const hasSelectedUnit = totalUnits > 0;
 
     // Reset slider value whenever totalUnits changes
     useEffect(() => {
@@ -91,7 +92,9 @@ const UnitSplitter = ({ totalUnits, onSplit }: IUnitSplitterProps) => {
                     // ends, and the counts sitting above them, stay inside the panel.
                     paddingX: `${SLIDER_INSET_PX}px`,
                     "& .MuiTypography-root": {
-                        color: "rgba(255, 143, 0, 0.5)",
+                        color: "rgba(216,194,156,.7)",
+                        fontFamily: hocDisplayFontFamily,
+                        fontSynthesis: "none",
                         transition: "all 0.2s ease",
                     },
                     "&:hover .MuiTypography-root": {
@@ -100,13 +103,13 @@ const UnitSplitter = ({ totalUnits, onSplit }: IUnitSplitterProps) => {
                 }}
             >
                 <Box sx={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
-                    <Typography level="body-sm">{splitValue}</Typography>
-                    <Typography level="body-sm">{totalUnits - splitValue}</Typography>
+                    <Typography level="body-sm">{hasSelectedUnit ? splitValue : 0}</Typography>
+                    <Typography level="body-sm">{hasSelectedUnit ? totalUnits - splitValue : 1}</Typography>
                 </Box>
 
                 <Slider
                     sx={{
-                        color: "#FF8F00", // Dark Orange Gold
+                        color: "#9a5a26",
                         padding: "4px 0",
                         height: 10,
                         "&:hover": {
@@ -126,31 +129,37 @@ const UnitSplitter = ({ totalUnits, onSplit }: IUnitSplitterProps) => {
                             },
                         },
                         "& .MuiSlider-rail": {
-                            height: 10,
-                            opacity: 0.5,
-                            backgroundColor: "#FF8F00", // Match main color
+                            height: 6.5,
+                            opacity: 1,
+                            background:
+                                "linear-gradient(180deg,#1b0d07 0%,#080504 66%,#6b3516 67%,#6b3516 80%,#1b0d07 81%)",
+                            border: "1px solid rgba(147,92,43,.72)",
+                            boxShadow: "inset 0 1px 3px #000, 0 1px 2px rgba(190,117,50,.25)",
                         },
                         "& .MuiSlider-track": {
-                            height: 10,
-                            border: "none",
-                            backgroundColor: "#FF8F00", // Explicitly Orange/Gold
+                            height: 6.5,
+                            border: "1px solid rgba(188,111,47,.68)",
+                            background: "linear-gradient(180deg,#9a4e1d,#3a1809 55%,#7a3514)",
+                            boxShadow: "inset 0 1px 2px rgba(255,194,108,.24)",
                         },
                     }}
-                    value={splitValue}
+                    value={hasSelectedUnit ? splitValue : 0}
                     onChange={handleSliderChange}
-                    min={1}
-                    max={totalUnits - 1}
+                    min={hasSelectedUnit ? 1 : 0}
+                    max={hasSelectedUnit ? Math.max(1, totalUnits - 1) : 1}
+                    track={hasSelectedUnit ? "normal" : false}
+                    disabled={!hasSelectedUnit}
                     step={1}
                     aria-label="Unit Split Slider"
                 />
             </Stack>
-            <Stack direction="row" spacing={2} sx={{ marginTop: 2, marginBottom: 2 }}>
+            <Stack direction="row" spacing={2} sx={{ width: "93%", mx: "auto", marginTop: 2, marginBottom: 2 }}>
                 <Tooltip title="Split (S)" placement="top" sx={shortcutTooltipSx}>
                     <Button
                         variant="plain"
                         size="sm"
                         onClick={handleAcceptSplit}
-                        sx={{ ...hocActionSoftButtonSx, flex: 1, minWidth: 0 }}
+                        sx={{ ...hocSidebarImageButtonSx("neutral"), flex: 1, minWidth: 0 }}
                     >
                         Split
                     </Button>
@@ -162,7 +171,7 @@ const UnitSplitter = ({ totalUnits, onSplit }: IUnitSplitterProps) => {
                         onClick={() => {
                             manager.Delete();
                         }}
-                        sx={{ ...hocActionDangerButtonSx, flex: 1, minWidth: 0 }}
+                        sx={{ ...hocSidebarImageButtonSx("danger"), flex: 1, minWidth: 0 }}
                     >
                         Delete
                     </Button>

--- a/game/core/src/ui/RightSideBar/index.tsx
+++ b/game/core/src/ui/RightSideBar/index.tsx
@@ -1,16 +1,13 @@
 import { IDamageStatistic } from "@heroesofcrypto/common";
-import { TRIM_WIDTH_PX as BOARD_EDGE_TRIM_WIDTH_PX } from "../boardEdgeTrim";
 import { setVolumeSlot } from "../audio/volumeSlot";
 import { FightLog } from "./FightLog";
-import DraggableToolbar, { TOOLBAR_TOP_LIFT_PX, TRIM_OVERHANG_PX, toolbarColumnHeightPx } from "../DraggableToolbar";
-import { SIDEBAR_BG, SIDEBAR_BG_IMAGE, SIDEBAR_BG_REPEAT, SIDEBAR_BG_SIZE } from "../LeftSideBar";
+import DraggableToolbar, { toolbarColumnHeightPx } from "../DraggableToolbar";
+import { RIGHT_SIDEBAR_BG_IMAGE, SIDEBAR_BG, SIDEBAR_BG_REPEAT, SIDEBAR_BG_SIZE } from "../LeftSideBar";
+import { SidebarFrame } from "../SidebarFrame";
 import Divider from "@mui/joy/Divider";
 import Box from "@mui/joy/Box";
 import LinearProgress from "@mui/joy/LinearProgress";
 import List from "@mui/joy/List";
-import ListItem from "@mui/joy/ListItem";
-import ListItemButton from "@mui/joy/ListItemButton";
-import ListItemContent from "@mui/joy/ListItemContent";
 import Sheet from "@mui/joy/Sheet";
 import Typography from "@mui/joy/Typography";
 import React, { useEffect, useState, useCallback, useLayoutEffect, useRef } from "react";
@@ -18,21 +15,12 @@ import Button from "@mui/joy/Button";
 import { useNavigate } from "react-router";
 import { usePixiManager } from "../../pixi/PixiGameManager";
 import { images } from "../../generated/image_imports";
-import Toggler from "../Toggler";
-import { hocColors, hocFontFamily, hocObsidianPanelSx } from "../hocTheme";
+import { hocColors, hocDisplayFontFamily, hocSidebarImageButtonSx, hocSidebarSectionSx } from "../hocTheme";
 import FightControlToggler from "./FightControlToggler";
 import { FullscreenToggle } from "./FullscreenToggle";
 import { WalletLinker } from "../WalletLinker";
 import { IWindowSize } from "../../scenes/VisibleState";
-
-// Everything below the button row runs the full width of that row: from the button column's left rim —
-// which reaches back past the sidebar's padding to meet the board trim — to the damage table's right edge.
-// Left on the padding they came out a rim's width narrower than the panels above and read as a separate,
-// indented column.
-const fullBleedSx = {
-    ml: `-${TRIM_OVERHANG_PX}px`,
-    width: `calc(100% + ${TRIM_OVERHANG_PX}px)`,
-} as const;
+import { sidebarPlainFrameSideInsetPx, sidebarPlainFrameVerticalInsetPx } from "../LeftSideBar/sidebarMetrics";
 
 // Floor for the fight log. Below this the bar as a whole scrolls rather than squeezing the log to nothing.
 const LOG_MIN_HEIGHT_PX = 168;
@@ -49,88 +37,7 @@ const hocBronzeScrollSx = {
     "&::-webkit-scrollbar-thumb:hover": { backgroundColor: "rgba(255, 143, 0, 0.55)" },
 } as const;
 
-interface IDamageStatsTogglerProps {
-    unitStatsElements: React.ReactNode;
-}
-
 const damageIcon = new URL("../../../images/damage_icon.webp", import.meta.url).toString(); // [NEW]
-
-const DamageStatsToggler: React.FC<IDamageStatsTogglerProps> = ({
-    unitStatsElements,
-}: {
-    unitStatsElements: React.ReactNode;
-}) => (
-    /* @ts-ignore: style params */
-    <ListItem style={{ "--List-nestedInsetStart": "0px" }} nested>
-        <Toggler
-            renderToggle={({ open, setOpen }) => (
-                <ListItemButton
-                    onClick={() => setOpen(!open)}
-                    sx={{
-                        // Built as a CONTROL, not a list row, and specifically to match the button column
-                        // beside it: the SAME obsidian fill the toolbar shell uses, so the two surfaces are
-                        // literally the same colour rather than merely similar.
-                        ...hocObsidianPanelSx,
-                        // No outline of any kind. The toolbar column is a floating object over the board and
-                        // earns a bronze edge; this header sits ON the sidebar, where any edge — the outer
-                        // border or the shell's inset rim, which reads as a second hairline — turned into a
-                        // frame competing with everything around it. Only the drop shadow is kept, so the
-                        // panel still lifts off the leather, and the ember is left to the glyph and label.
-                        border: "none",
-                        boxShadow: "0 4px 14px rgba(0,0,0,.7)",
-                        py: 1.5,
-                        px: 1.5,
-                        my: 0.5,
-                        transition: "background-image 0.25s",
-                        "&:hover": {
-                            backgroundImage: "linear-gradient(180deg, rgba(28,28,26,.96), rgba(9,9,9,.96))",
-                        },
-                    }}
-                >
-                    <Box
-                        component="img"
-                        src={damageIcon} // Use the new icon
-                        sx={{
-                            width: "36px",
-                            height: "36px",
-                            filter: open ? "none" : "grayscale(100%)",
-                            opacity: open ? 1 : 0.7,
-                            mr: 1.5, // Slight spacing
-                        }}
-                    />
-                    <ListItemContent>
-                        <Typography
-                            level="title-sm"
-                            sx={{
-                                fontFamily: hocFontFamily,
-                                fontWeight: 700,
-                                letterSpacing: "0.09em",
-                                textTransform: "uppercase",
-                                color: open ? hocColors.orange : hocColors.parchment,
-                            }}
-                        >
-                            Damage
-                        </Typography>
-                    </ListItemContent>
-                    <Box
-                        component="img"
-                        src={images.tr_up}
-                        sx={{
-                            width: "12px",
-                            transform: open ? "none" : "rotate(180deg)",
-                            transition: "transform 0.2s",
-                            filter: open
-                                ? "brightness(0) saturate(100%) invert(58%) sepia(91%) saturate(3089%) hue-rotate(2deg) brightness(103%) contrast(104%)"
-                                : "none",
-                        }}
-                    />
-                </ListItemButton>
-            )}
-        >
-            <List sx={{ gap: 0, pt: 2 }}>{unitStatsElements}</List>
-        </Toggler>
-    </ListItem>
-);
 
 export default function RightSideBar({
     gameStarted,
@@ -274,21 +181,32 @@ export default function RightSideBar({
                 width: `${barSize}px`,
                 top: 0,
                 right: 0,
-                p: 2,
+                // All combat blocks share one left edge. The compensation preserves the existing visual
+                // gap at the right rail and mirrors that gap on the board-facing side.
+                pl: gameStarted ? `${Math.max(0, sidebarPlainFrameSideInsetPx(barSize) - 6)}px` : "6px",
+                // Setup keeps its safer inset for wide accordion controls and scrollbars.
+                pr: gameStarted ? 0 : `${sidebarPlainFrameSideInsetPx(barSize)}px`,
+                pt: `${sidebarPlainFrameVerticalInsetPx(windowSize.height)}px`,
+                pb: `${sidebarPlainFrameVerticalInsetPx(windowSize.height)}px`,
                 // flexShrink: 0,
                 display: "flex",
                 flexDirection: "column",
                 gap: 2,
                 // Board-facing edge, mirrored from LeftSideBar: widened to the gold trim's width and the
                 // background clipped to the padding box, so the leather ends where the trim begins.
-                borderLeft: `${BOARD_EDGE_TRIM_WIDTH_PX}px solid #0a0705`,
                 backgroundClip: "padding-box",
                 boxShadow: "inset 1px 0 0 rgba(120,104,80,.22), -6px 0 18px rgba(0,0,0,.7)",
-                overflowY: "auto", // Allow vertical scrolling
+                // Setup must always fit as one fixed command deck. Combat/ranked screens can still scroll
+                // when their logs or server-provided panels genuinely exceed the viewport.
+                overflowY: !gameStarted && !rankedPanel ? "hidden" : "auto",
                 overflowX: "hidden", // Prevent horizontal scrolling
+                // Reserve the scrollbar lane even while the short/collapsed layout does not need it.
+                // Otherwise opening an augment makes the scrollbar appear, steals width, and visibly
+                // jerks every 9-slice container frame and its right rail to the left.
+                scrollbarGutter: !gameStarted && !rankedPanel ? "auto" : "stable",
                 // Same ground as the left bar.
                 backgroundColor: SIDEBAR_BG,
-                backgroundImage: SIDEBAR_BG_IMAGE,
+                backgroundImage: RIGHT_SIDEBAR_BG_IMAGE,
                 backgroundSize: SIDEBAR_BG_SIZE,
                 backgroundRepeat: SIDEBAR_BG_REPEAT,
                 backgroundPosition: "right center",
@@ -306,6 +224,8 @@ export default function RightSideBar({
                     size="sm"
                     sx={{
                         gap: 1,
+                        px: 0,
+                        "--ListItem-paddingX": "0px",
                         // Claim the bar's full height so the bottom control strip can sit on the very edge.
                         flexGrow: 1,
                         minHeight: 0,
@@ -328,7 +248,6 @@ export default function RightSideBar({
                                 // the damage table has anything to gain from the bar's spare height, and
                                 // claiming it here is what pushed the log down the bar.
                                 alignItems: "flex-start",
-                                gap: 1,
                                 // No bottom margin of its own: the List already puts a gap between every
                                 // child, and carrying a second one here opened a band of bare leather
                                 // between the button column and the log. The log is measured on the first
@@ -340,9 +259,10 @@ export default function RightSideBar({
                                 // by where it ends.
                                 height: `${toolbarColumnHeightPx()}px`,
                                 flexShrink: 0,
+                                gap: "6px",
                             }}
                         >
-                            <DraggableToolbar flushToTrim />
+                            <DraggableToolbar />
                             {/* Shown from the first turn, not from the first hit: the table keeps its place
                                 and simply lists nothing until damage is dealt, instead of appearing out of
                                 nowhere mid-fight and pushing everything below it. */}
@@ -355,15 +275,38 @@ export default function RightSideBar({
                                     flex: "1 1 auto",
                                     minWidth: 0,
                                     alignSelf: "stretch",
-                                    position: "relative",
-                                    // Lifted by exactly as much as the button column is, so both start on
-                                    // the same line. Its bottom is pinned by the stretch, so this only ever
-                                    // adds height at the top.
-                                    mt: `-${TOOLBAR_TOP_LIFT_PX}px`,
+                                    ...hocSidebarSectionSx("board"),
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    p: 0,
                                 }}
                             >
-                                <Box sx={{ position: "absolute", inset: 0, overflowY: "auto", ...hocBronzeScrollSx }}>
-                                    <DamageStatsToggler unitStatsElements={unitStatsElements} />
+                                <Box
+                                    sx={{
+                                        flex: "0 0 48px",
+                                        display: "flex",
+                                        alignItems: "center",
+                                        px: "10px",
+                                        gap: "8px",
+                                        borderBottom: "1px solid rgba(112,75,42,.48)",
+                                    }}
+                                >
+                                    <Box component="img" src={damageIcon} sx={{ width: 28, height: 28 }} />
+                                    <Typography
+                                        sx={{
+                                            flex: 1,
+                                            textAlign: "center",
+                                            fontFamily: hocDisplayFontFamily,
+                                            fontSize: "0.9rem",
+                                            letterSpacing: "0.13em",
+                                            color: hocColors.gold,
+                                        }}
+                                    >
+                                        DAMAGE
+                                    </Typography>
+                                </Box>
+                                <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto", p: "10px", ...hocBronzeScrollSx }}>
+                                    {unitStatsElements}
                                 </Box>
                             </Box>
                         </Box>
@@ -380,42 +323,78 @@ export default function RightSideBar({
                         <Box
                             ref={logBoxRef}
                             sx={{
-                                ...fullBleedSx,
                                 display: "flex",
                                 flexDirection: "column",
                                 minHeight: `${LOG_MIN_HEIGHT_PX}px`,
+                                ...hocSidebarSectionSx("team"),
+                                p: 0,
                                 ...(frozenLogHeight === null
                                     ? { flex: "1 1 auto" }
                                     : { flex: "0 0 auto", height: `${frozenLogHeight}px` }),
                             }}
                         >
-                            <FightLog text={attackText} />
+                            <Box
+                                sx={{
+                                    flex: "0 0 42px",
+                                    display: "grid",
+                                    gridTemplateColumns: "32px 1fr 20px",
+                                    alignItems: "center",
+                                    px: "8px",
+                                    borderBottom: "1px solid rgba(112,75,42,.48)",
+                                }}
+                            >
+                                <Box
+                                    component="img"
+                                    src={images.flag_red_icon}
+                                    sx={{ width: 28, height: 28, objectFit: "contain" }}
+                                />
+                                <Typography
+                                    sx={{
+                                        textAlign: "center",
+                                        fontFamily: hocDisplayFontFamily,
+                                        fontSize: "0.86rem",
+                                        letterSpacing: "0.13em",
+                                        color: hocColors.gold,
+                                    }}
+                                >
+                                    BATTLE LOG
+                                </Typography>
+                                <Box
+                                    component="img"
+                                    src={images.tr_up}
+                                    sx={{ width: 11, transform: "rotate(180deg)" }}
+                                />
+                            </Box>
+                            <Box sx={{ flex: 1, minHeight: 0, display: "flex", p: "4px" }}>
+                                <FightLog text={attackText} />
+                            </Box>
                         </Box>
                     )}
-                    {rankedPanel && gameStarted && <Box sx={{ ...fullBleedSx, mt: 1 }}>{rankedPanel}</Box>}
+                    {rankedPanel && gameStarted && <Box sx={{ mt: 1 }}>{rankedPanel}</Box>}
                     {/* Sandbox has no ranked sheet to carry the control, and no forfeit either — there is no
                         opponent to award the win to. It still needs a way out of a running fight, so it gets
                         the same bare button, wired to leave rather than to concede. */}
                     {!rankedPanel && gameStarted && (
-                        <Box sx={{ ...fullBleedSx, mt: 1 }}>
+                        <Box sx={{ mt: 1 }}>
                             <Button
                                 variant="soft"
                                 color="danger"
                                 onClick={() => navigate("/play")}
-                                sx={{ width: "100%" }}
+                                sx={{ width: "100%", ...hocSidebarImageButtonSx("danger") }}
                             >
                                 EXIT FIGHT
                             </Button>
                         </Box>
                     )}
-                    <Divider sx={fullBleedSx} />
+                    <Divider />
                     {showWallet && <WalletLinker />}
                     {/* The strip under EXIT FIGHT, in flow: fullscreen hard left, the music control hard
                         right. Both used to be pinned to the window's bottom-right corner on their own
                         layer, which floated them OVER the exit button instead of under it. */}
                     <Box
                         sx={{
-                            ...fullBleedSx,
+                            width: "100%",
+                            pl: gameStarted ? 0 : `${Math.max(0, sidebarPlainFrameSideInsetPx(barSize) - 6)}px`,
                             display: "flex",
                             alignItems: "center",
                             justifyContent: "space-between",
@@ -430,6 +409,7 @@ export default function RightSideBar({
                     </Box>
                 </List>
             </Box>
+            <SidebarFrame side="right" width={barSize} height={windowSize.height} />
         </Sheet>
     );
 }


### PR DESCRIPTION
## Summary
- restyles the right command deck and board configuration controls
- refines ranked map reveal and timer presentation
- aligns combat, sandbox, synergy and unit controls with the selected fantasy theme

## Asset policy
- no raster image files are included in this PR
- image originals remain in Dropbox and checkpoint X

## Checks
- `bunx tsc --noEmit -p game/core/tsconfig.json`
- ESLint on all changed TypeScript/TSX files
- `bun test game/core/src/gameImageAssetPolicy.test.ts game/core/src/ui/PickAndBan/mapDisplay.test.ts`